### PR TITLE
Clearing state after navigating.

### DIFF
--- a/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewScreen.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewScreen.kt
@@ -32,6 +32,8 @@ fun EventOverviewScreen(
                     phaseId = selectedPhase.id
                 )
             )
+
+            viewModel.navigatedToPhase()
         }
     }
 

--- a/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewViewModel.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewViewModel.kt
@@ -69,6 +69,21 @@ class EventOverviewViewModel @Inject constructor(
             }
         }
     }
+
+    /**
+     * When we navigate to a phase, we should clear our selected phase so that we don't
+     * continue to show it.
+     */
+    fun navigatedToPhase() {
+        val currentState =
+            _viewState.value as? EventOverviewViewState.Success
+
+        if (currentState != null) {
+            _viewState.value = currentState.copy(
+                selectedPhase = null,
+            )
+        }
+    }
 }
 
 private fun StandingsPlacement.toDisplayModel(): StandingsPlacementDisplayModel {

--- a/app/src/main/java/com/adammcneilly/pocketleague/eventsummary/ui/EventSummaryListScreen.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/eventsummary/ui/EventSummaryListScreen.kt
@@ -31,6 +31,8 @@ fun EventSummaryListScreen(
                     eventId = selectedEvent.id,
                 )
             )
+
+            viewModel.navigatedToEventOverview()
         }
     }
 

--- a/app/src/main/java/com/adammcneilly/pocketleague/eventsummary/ui/EventSummaryListViewModel.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/eventsummary/ui/EventSummaryListViewModel.kt
@@ -58,6 +58,21 @@ class EventSummaryListViewModel @Inject constructor(
             }
         }
     }
+
+    /**
+     * When we navigate to an event overview, we should clear our selected event so that we don't
+     * continue to show it.
+     */
+    fun navigatedToEventOverview() {
+        val currentState =
+            _viewState.value as? EventSummaryListViewState.Success
+
+        if (currentState != null) {
+            _viewState.value = currentState.copy(
+                selectedEvent = null,
+            )
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

* Clearing the selected item after navigating, which allows us to click the same event twice. 

## How It Was Tested

* Verified I could click the same event twice.  