### PR TITLE
Showing empty state on event if necessary.

### DIFF
--- a/app/src/androidTest/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewContentTest.kt
+++ b/app/src/androidTest/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewContentTest.kt
@@ -1,0 +1,102 @@
+package com.adammcneilly.pocketleague.eventoverview.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasProgressBarRangeInfo
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.adammcneilly.pocketleague.R
+import com.adammcneilly.pocketleague.core.ui.UIText
+import com.adammcneilly.pocketleague.standings.ui.StandingsDisplayModel
+import org.junit.Rule
+import org.junit.Test
+
+class EventOverviewContentTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun renderLoadingState() {
+        val viewState = EventOverviewViewState(
+            showLoading = true,
+        )
+
+        composeTestRule.setContent {
+            EventOverviewContent(
+                viewState = viewState,
+            )
+        }
+
+        composeTestRule
+            .onNode(hasProgressBarRangeInfo(ProgressBarRangeInfo.Indeterminate))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun renderErrorMessage() {
+        val errorMessage = "Whoops"
+
+        val viewState = EventOverviewViewState(
+            showLoading = false,
+            errorMessage = UIText.StringText(errorMessage),
+        )
+
+        composeTestRule.setContent {
+            EventOverviewContent(
+                viewState = viewState,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(errorMessage)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun renderEmptyStates() {
+        val eventName = "Open Qualifier"
+        val startDate = "Feb 11, 2022"
+
+        val eventOverview = EventOverviewDisplayModel(
+            eventName = eventName,
+            startDate = startDate,
+            phases = emptyList(),
+            standings = StandingsDisplayModel(
+                placements = emptyList(),
+            ),
+        )
+
+        val viewState = EventOverviewViewState(
+            showLoading = false,
+            event = eventOverview,
+        )
+
+        composeTestRule.setContent {
+            EventOverviewContent(
+                viewState = viewState,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(eventName)
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(startDate)
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(
+                composeTestRule.activity.getString(R.string.bracket_information_unavailable)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(
+                composeTestRule.activity.getString(R.string.standings_information_unavailable)
+            )
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/adammcneilly/pocketleague/core/ui/InformationUnavailableCard.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/core/ui/InformationUnavailableCard.kt
@@ -13,6 +13,10 @@ import com.adammcneilly.pocketleague.core.ui.theme.PocketLeagueTheme
 
 private const val CARD_ASPECT_RATIO = 4.0F
 
+/**
+ * An instance of a [Material3Card] that presents a label explaining that we don't have
+ * information we're trying to show in a section.
+ */
 @Composable
 fun InformationUnavailableCard(
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/adammcneilly/pocketleague/core/ui/InformationUnavailableCard.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/core/ui/InformationUnavailableCard.kt
@@ -1,0 +1,49 @@
+package com.adammcneilly.pocketleague.core.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.adammcneilly.pocketleague.core.ui.theme.PocketLeagueTheme
+
+private const val CARD_ASPECT_RATIO = 4.0F
+
+@Composable
+fun InformationUnavailableCard(
+    modifier: Modifier = Modifier,
+) {
+    Material3Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .aspectRatio(CARD_ASPECT_RATIO),
+    ) {
+        Box {
+            Text(
+                text = "This information is currently unavailable.",
+                modifier = Modifier
+                    .align(Alignment.Center),
+            )
+        }
+    }
+}
+
+@Preview(
+    name = "Night Mode",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Preview(
+    name = "Day Mode",
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+)
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun InformationUnavailableCardPreview() {
+    PocketLeagueTheme {
+        InformationUnavailableCard()
+    }
+}

--- a/app/src/main/java/com/adammcneilly/pocketleague/core/ui/TextCard.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/core/ui/TextCard.kt
@@ -14,11 +14,11 @@ import com.adammcneilly.pocketleague.core.ui.theme.PocketLeagueTheme
 private const val CARD_ASPECT_RATIO = 4.0F
 
 /**
- * An instance of a [Material3Card] that presents a label explaining that we don't have
- * information we're trying to show in a section.
+ * An instance of a [Material3Card] that presents some [text] to the user.
  */
 @Composable
-fun InformationUnavailableCard(
+fun TextCard(
+    text: String,
     modifier: Modifier = Modifier,
 ) {
     Material3Card(
@@ -28,7 +28,7 @@ fun InformationUnavailableCard(
     ) {
         Box {
             Text(
-                text = "This information is currently unavailable.",
+                text = text,
                 modifier = Modifier
                     .align(Alignment.Center),
             )
@@ -46,8 +46,10 @@ fun InformationUnavailableCard(
 )
 @Composable
 @Suppress("UnusedPrivateMember")
-private fun InformationUnavailableCardPreview() {
+private fun TextCardPreview() {
     PocketLeagueTheme {
-        InformationUnavailableCard()
+        TextCard(
+            text = "This information is currently unavailable."
+        )
     }
 }

--- a/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewContent.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewContent.kt
@@ -13,10 +13,12 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.adammcneilly.pocketleague.R
 import com.adammcneilly.pocketleague.core.ui.CenteredMaterial3CircularProgressIndicator
-import com.adammcneilly.pocketleague.core.ui.InformationUnavailableCard
+import com.adammcneilly.pocketleague.core.ui.TextCard
 import com.adammcneilly.pocketleague.core.ui.Material3Card
 import com.adammcneilly.pocketleague.core.ui.getValue
 import com.adammcneilly.pocketleague.core.ui.theme.PocketLeagueTheme
@@ -67,7 +69,7 @@ private fun SuccessContent(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         HeaderLabel(
-            text = "Summary",
+            text = stringResource(R.string.summary),
         )
 
         Material3Card {
@@ -77,7 +79,7 @@ private fun SuccessContent(
         }
 
         HeaderLabel(
-            text = "Brackets",
+            text = stringResource(R.string.brackets),
         )
 
         if (event.phases.isNotEmpty()) {
@@ -85,11 +87,13 @@ private fun SuccessContent(
                 phases = event.phases,
             )
         } else {
-            InformationUnavailableCard()
+            TextCard(
+                text = stringResource(R.string.bracket_information_unavailable),
+            )
         }
 
         HeaderLabel(
-            text = "Standings",
+            text = stringResource(R.string.standings),
         )
 
         if (event.standings.placements.isNotEmpty()) {
@@ -99,7 +103,9 @@ private fun SuccessContent(
                 )
             }
         } else {
-            InformationUnavailableCard()
+            TextCard(
+                text = stringResource(R.string.standings_information_unavailable),
+            )
         }
     }
 }

--- a/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewContent.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewContent.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adammcneilly.pocketleague.R
 import com.adammcneilly.pocketleague.core.ui.CenteredMaterial3CircularProgressIndicator
-import com.adammcneilly.pocketleague.core.ui.TextCard
 import com.adammcneilly.pocketleague.core.ui.Material3Card
+import com.adammcneilly.pocketleague.core.ui.TextCard
 import com.adammcneilly.pocketleague.core.ui.getValue
 import com.adammcneilly.pocketleague.core.ui.theme.PocketLeagueTheme
 import com.adammcneilly.pocketleague.phase.ui.PhaseDisplayModel

--- a/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewContent.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/eventoverview/ui/EventOverviewContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.adammcneilly.pocketleague.core.ui.CenteredMaterial3CircularProgressIndicator
+import com.adammcneilly.pocketleague.core.ui.InformationUnavailableCard
 import com.adammcneilly.pocketleague.core.ui.Material3Card
 import com.adammcneilly.pocketleague.core.ui.getValue
 import com.adammcneilly.pocketleague.core.ui.theme.PocketLeagueTheme
@@ -79,18 +80,26 @@ private fun SuccessContent(
             text = "Brackets",
         )
 
-        PhaseList(
-            phases = event.phases,
-        )
+        if (event.phases.isNotEmpty()) {
+            PhaseList(
+                phases = event.phases,
+            )
+        } else {
+            InformationUnavailableCard()
+        }
 
         HeaderLabel(
             text = "Standings",
         )
 
-        Material3Card {
-            StandingsList(
-                standings = event.standings,
-            )
+        if (event.standings.placements.isNotEmpty()) {
+            Material3Card {
+                StandingsList(
+                    standings = event.standings,
+                )
+            }
+        } else {
+            InformationUnavailableCard()
         }
     }
 }
@@ -147,6 +156,40 @@ private fun EventOverviewContentPreview() {
                 onClick = {},
             ),
         ),
+        startDate = "November 12, 2021",
+        standings = standings,
+    )
+
+    val viewState = EventOverviewViewState(
+        showLoading = false,
+        event = event,
+    )
+
+    PocketLeagueTheme {
+        Surface {
+            EventOverviewContent(viewState)
+        }
+    }
+}
+
+@Preview(
+    name = "Night Mode",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Preview(
+    name = "Day Mode",
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+)
+@Composable
+@Suppress("LongMethod")
+private fun EventOverviewUpcomingContentPreview() {
+    val standings = StandingsDisplayModel(
+        placements = emptyList(),
+    )
+
+    val event = EventOverviewDisplayModel(
+        eventName = "Main Event",
+        phases = emptyList(),
         startDate = "November 12, 2021",
         standings = standings,
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,9 @@
 <resources>
     <string name="app_name">Pocket League</string>
     <string name="event_image_content_description">Event Image</string>
+    <string name="summary">Summary</string>
+    <string name="brackets">Brackets</string>
+    <string name="bracket_information_unavailable">Bracket information is currently unavailable.</string>
+    <string name="standings">Standings</string>
+    <string name="standings_information_unavailable">Standings information is currently unavailable.</string>
 </resources>


### PR DESCRIPTION
## Summary

* Adds an empty state on event overview for relevant sections. 

## How It Was Tested

* Manual testing, new UI tests. 

## Screenshot/Gif

![Screen Shot 2022-02-05 at 3 09 16 PM](https://user-images.githubusercontent.com/9515997/152657294-40b560aa-9556-452f-8037-277dfd4883e2.png)
