### PR TITLE
Cleaning up date usages.

### DIFF
--- a/app/src/androidTest/java/com/adammcneilly/pocketleague/ui/MatchListItemScreenshotTest.kt
+++ b/app/src/androidTest/java/com/adammcneilly/pocketleague/ui/MatchListItemScreenshotTest.kt
@@ -37,7 +37,7 @@ class MatchListItemScreenshotTest : ScreenshotTest {
             event = Event(
                 name = "Test Event",
             ),
-            date = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()),
+            dateUTC = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()),
             blueTeam = MatchTeamResult(
                 score = 5,
                 winner = true,
@@ -68,7 +68,7 @@ class MatchListItemScreenshotTest : ScreenshotTest {
             event = Event(
                 name = "Test Event",
             ),
-            date = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()),
+            dateUTC = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()),
             blueTeam = MatchTeamResult(
                 score = 0,
                 winner = false,

--- a/app/src/main/java/com/adammcneilly/pocketleague/ui/MatchListItem.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/ui/MatchListItem.kt
@@ -30,12 +30,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.adammcneilly.pocketleague.core.models.Match
 import com.adammcneilly.pocketleague.core.models.MatchTeamResult
-import com.google.accompanist.placeholder.material.placeholder
 import com.google.accompanist.placeholder.placeholder
 import kotlinx.datetime.Clock
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
+import kotlinx.datetime.Instant
 
 /**
  * Displays a match between two teams inside a list item.
@@ -68,12 +65,12 @@ fun MatchListItem(
             )
 
             Text(
-                text = match.date?.getRelativeTimestamp().orEmpty(),
+                text = match.dateUTC?.getRelativeTimestamp().orEmpty(),
                 style = MaterialTheme.typography.labelSmall,
                 modifier = Modifier
                     .defaultMinSize(minWidth = 50.dp)
                     .placeholder(
-                        visible = match.date == null,
+                        visible = match.dateUTC == null,
                         shape = CircleShape,
                         color = MaterialTheme.colorScheme.inverseSurface,
                     )
@@ -171,11 +168,10 @@ private fun MatchTeamResult.getInlineContent(): Map<String, InlineTextContent> {
 
 private const val HOURS_IN_DAY = 24
 
-private fun LocalDateTime.getRelativeTimestamp(): String {
+private fun Instant.getRelativeTimestamp(): String {
     val now = Clock.System.now()
-    val matchInstant = this.toInstant(TimeZone.currentSystemDefault())
 
-    val duration = now.minus(matchInstant)
+    val duration = now.minus(this)
 
     return when {
         duration.inWholeHours < HOURS_IN_DAY -> {

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/models/EventListRequest.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/models/EventListRequest.kt
@@ -1,6 +1,6 @@
 package com.adammcneilly.pocketleague.core.data.models
 
-import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Instant
 
 /**
  * Defines all of the information that will be passed into a request for a list of events.
@@ -10,7 +10,7 @@ import kotlinx.datetime.LocalDateTime
 data class EventListRequest(
     val group: String? = null,
     val tiers: List<String>? = null,
-    val after: LocalDateTime? = null,
-    val before: LocalDateTime? = null,
-    val date: LocalDateTime? = null,
+    val after: Instant? = null,
+    val before: Instant? = null,
+    val date: Instant? = null,
 )

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/models/MatchListRequest.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/models/MatchListRequest.kt
@@ -1,6 +1,6 @@
 package com.adammcneilly.pocketleague.core.data.models
 
-import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Instant
 
 /**
  * Defines all of the information that will be passed into a request
@@ -9,8 +9,8 @@ import kotlinx.datetime.LocalDateTime
  * If the information is null, it won't be used to filter a response at all.
  */
 data class MatchListRequest(
-    val after: LocalDateTime? = null,
-    val before: LocalDateTime? = null,
+    val after: Instant? = null,
+    val before: Instant? = null,
     val group: String? = null,
     val eventId: String? = null,
     val stageId: String? = null,

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/mappers/OctaneGGEventMapper.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/mappers/OctaneGGEventMapper.kt
@@ -6,8 +6,6 @@ import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.EventRegion
 import com.adammcneilly.pocketleague.core.models.EventTier
 import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
 /**
  * Converts an [OctaneGGEvent] entity into an [Event] within the Pocket League domain.
@@ -16,12 +14,8 @@ fun OctaneGGEvent.toEvent(): Event {
     return Event(
         id = this.id ?: "ID Not Available",
         name = this.name ?: "Name Not Available",
-        startDate = this.startDate?.let {
-            Instant.parse(it)
-        }?.toLocalDateTime(TimeZone.UTC),
-        endDate = this.endDate?.let {
-            Instant.parse(it)
-        }?.toLocalDateTime(TimeZone.UTC),
+        startDateUTC = this.startDate?.let(Instant.Companion::parse),
+        endDateUTC = this.endDate?.let(Instant.Companion::parse),
         imageUrl = this.image,
         stages = this.stages?.map(OctaneGGStage::toEventStage).orEmpty(),
         tier = this.tier.toEventTier(),

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/mappers/OctaneGGMatchMapper.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/mappers/OctaneGGMatchMapper.kt
@@ -4,8 +4,6 @@ import com.adammcneilly.pocketleague.core.data.remote.octanegg.models.OctaneGGMa
 import com.adammcneilly.pocketleague.core.models.EventStage
 import com.adammcneilly.pocketleague.core.models.Match
 import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
 /**
  * Converts an [OctaneGGMatch] to a [Match] entity.
@@ -26,9 +24,7 @@ fun OctaneGGMatch.toMatch(): Match? {
     return Match(
         id = this.id,
         event = this.event.toEvent(),
-        date = this.date?.let { date ->
-            Instant.parse(date)
-        }?.toLocalDateTime(TimeZone.UTC),
+        dateUTC = this.dateUTC?.let(Instant.Companion::parse),
         blueTeam = this.blue.toMatchTeamResult(),
         orangeTeam = this.orange.toMatchTeamResult(),
         stage = this.stage?.toEventStage() ?: EventStage(),

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/mappers/OctaneGGStageMapper.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/mappers/OctaneGGStageMapper.kt
@@ -3,8 +3,6 @@ package com.adammcneilly.pocketleague.core.data.remote.octanegg.mappers
 import com.adammcneilly.pocketleague.core.data.remote.octanegg.models.OctaneGGStage
 import com.adammcneilly.pocketleague.core.models.EventStage
 import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
 /**
  * Converts an [OctaneGGStage] to an [EventStage].
@@ -14,12 +12,8 @@ fun OctaneGGStage.toEventStage(): EventStage {
         id = this.id.toString(),
         name = this.name.orEmpty(),
         region = this.region.orEmpty(),
-        startDate = this.startDate?.let {
-            Instant.parse(it)
-        }?.toLocalDateTime(TimeZone.UTC),
-        endDate = this.endDate?.let {
-            Instant.parse(it)
-        }?.toLocalDateTime(TimeZone.UTC),
+        startDateUTC = this.startDateUTC?.let(Instant.Companion::parse),
+        endDateUTC = this.endDateUTC?.let(Instant.Companion::parse),
         liquipedia = this.liquipedia.orEmpty(),
         qualifier = this.qualifier == true,
         lan = this.lan == true,

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/models/OctaneGGMatch.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/models/OctaneGGMatch.kt
@@ -15,7 +15,7 @@ data class OctaneGGMatch(
     @SerialName("event")
     val event: OctaneGGEvent? = null,
     @SerialName("date")
-    val date: String? = null,
+    val dateUTC: String? = null,
     @SerialName("blue")
     val blue: OctaneGGMatchTeamResult? = null,
     @SerialName("orange")

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/models/OctaneGGStage.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/models/OctaneGGStage.kt
@@ -11,11 +11,11 @@ data class OctaneGGStage(
     @SerialName("_id")
     val id: Int? = null,
     @SerialName("endDate")
-    val endDate: String? = null,
+    val endDateUTC: String? = null,
     @SerialName("name")
     val name: String? = null,
     @SerialName("startDate")
-    val startDate: String? = null,
+    val startDateUTC: String? = null,
     @SerialName("prize")
     val prize: OctaneGGPrize? = null,
     @SerialName("location")

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/services/OctaneGGEventService.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/services/OctaneGGEventService.kt
@@ -43,7 +43,7 @@ class OctaneGGEventService(
                 is DataState.Success -> {
                     val mappedEvents = apiResult.data.events?.map(OctaneGGEvent::toEvent).orEmpty()
 
-                    val sortedEvents = mappedEvents.sortedBy(Event::startDate)
+                    val sortedEvents = mappedEvents.sortedBy(Event::startDateUTC)
 
                     DataState.Success(sortedEvents)
                 }

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/services/OctaneGGEventService.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/services/OctaneGGEventService.kt
@@ -10,7 +10,6 @@ import com.adammcneilly.pocketleague.core.data.remote.octanegg.models.OctaneGGEv
 import com.adammcneilly.pocketleague.core.data.remote.octanegg.models.OctaneGGEventListResponse
 import com.adammcneilly.pocketleague.core.data.remote.octanegg.models.OctaneGGEventParticipants
 import com.adammcneilly.pocketleague.core.data.repositories.EventRepository
-import com.adammcneilly.pocketleague.core.datetime.DateTimeFormatter
 import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.Team
 import io.ktor.client.request.HttpRequestBuilder
@@ -108,9 +107,6 @@ class OctaneGGEventService(
 }
 
 private fun HttpRequestBuilder.addEventParameters(request: EventListRequest) {
-    val dateTimeFormatter = DateTimeFormatter()
-    val octaneGGDateFormat = "yyyy-MM-dd"
-
     if (request.group != null) {
         this.parameter("group", request.group)
     }
@@ -120,17 +116,14 @@ private fun HttpRequestBuilder.addEventParameters(request: EventListRequest) {
     }
 
     if (request.after != null) {
-        val afterString = dateTimeFormatter.formatLocalDateTime(request.after, octaneGGDateFormat)
-        this.parameter("after", afterString)
+        this.parameter("after", request.after.toString())
     }
 
     if (request.before != null) {
-        val beforeString = dateTimeFormatter.formatLocalDateTime(request.before, octaneGGDateFormat)
-        this.parameter("before", beforeString)
+        this.parameter("before", request.before.toString())
     }
 
     if (request.date != null) {
-        val dateString = dateTimeFormatter.formatLocalDateTime(request.date, octaneGGDateFormat)
-        this.parameter("date", dateString)
+        this.parameter("date", request.date.toString())
     }
 }

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/services/OctaneGGMatchService.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/services/OctaneGGMatchService.kt
@@ -8,7 +8,6 @@ import com.adammcneilly.pocketleague.core.data.remote.octanegg.mappers.toMatch
 import com.adammcneilly.pocketleague.core.data.remote.octanegg.models.OctaneGGMatch
 import com.adammcneilly.pocketleague.core.data.remote.octanegg.models.OctaneGGMatchListResponse
 import com.adammcneilly.pocketleague.core.data.repositories.MatchRepository
-import com.adammcneilly.pocketleague.core.datetime.DateTimeFormatter
 import com.adammcneilly.pocketleague.core.models.Match
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.parameter
@@ -82,17 +81,12 @@ class OctaneGGMatchService(
 }
 
 private fun HttpRequestBuilder.addMatchParameters(request: MatchListRequest) {
-    val dateTimeFormatter = DateTimeFormatter()
-    val octaneGGDateFormat = "yyyy-MM-dd"
-
     if (request.after != null) {
-        val afterString = dateTimeFormatter.formatLocalDateTime(request.after, octaneGGDateFormat)
-        this.parameter("after", afterString)
+        this.parameter("after", request.after.toString())
     }
 
     if (request.before != null) {
-        val beforeString = dateTimeFormatter.formatLocalDateTime(request.before, octaneGGDateFormat)
-        this.parameter("before", beforeString)
+        this.parameter("before", request.before.toString())
     }
 
     if (request.group != null) {

--- a/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/services/OctaneGGMatchService.kt
+++ b/core-data/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/data/remote/octanegg/services/OctaneGGMatchService.kt
@@ -67,7 +67,7 @@ class OctaneGGMatchService(
                     val mappedMatches =
                         apiResult.data.matches?.mapNotNull(OctaneGGMatch::toMatch).orEmpty()
 
-                    val sortedMatches = mappedMatches.sortedByDescending(Match::date)
+                    val sortedMatches = mappedMatches.sortedByDescending(Match::dateUTC)
 
                     DataState.Success(sortedMatches)
                 }

--- a/core-datetime/src/androidMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatter.kt
+++ b/core-datetime/src/androidMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatter.kt
@@ -1,7 +1,10 @@
 package com.adammcneilly.pocketleague.core.datetime
 
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toJavaLocalDateTime
+import kotlinx.datetime.toLocalDateTime
 import java.time.format.DateTimeFormatter
 
 /**
@@ -19,5 +22,21 @@ actual class DateTimeFormatter actual constructor() {
         val dateTimeFormatter = DateTimeFormatter.ofPattern(formatPattern)
 
         return localDateTime.toJavaLocalDateTime().format(dateTimeFormatter)
+    }
+
+    /**
+     * See commonMain documentation.
+     */
+    actual fun formatInstant(
+        instant: Instant,
+        formatPattern: String,
+        timeZone: TimeZone,
+    ): String? {
+        val localDateTime = instant.toLocalDateTime(timeZone)
+
+        return formatLocalDateTime(
+            localDateTime = localDateTime,
+            formatPattern = formatPattern,
+        )
     }
 }

--- a/core-datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatter.kt
+++ b/core-datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatter.kt
@@ -1,6 +1,8 @@
 package com.adammcneilly.pocketleague.core.datetime
 
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
 
 /**
  * A shared class between platforms that is used to format a date into a user friendly string.
@@ -15,5 +17,16 @@ expect class DateTimeFormatter constructor() {
     fun formatLocalDateTime(
         localDateTime: LocalDateTime,
         formatPattern: String,
+    ): String?
+
+    /**
+     * Given an [instant], treat it as a [LocalDateTime] and convert it into
+     * a user friendly string matching the supplied [formatPattern]. We'll format it using
+     * the supplied [timeZone] as well.
+     */
+    fun formatInstant(
+        instant: Instant,
+        formatPattern: String,
+        timeZone: TimeZone,
     ): String?
 }

--- a/core-datetime/src/iosMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatter.kt
+++ b/core-datetime/src/iosMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatter.kt
@@ -1,6 +1,9 @@
 package com.adammcneilly.pocketleague.core.datetime
 
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.toNSDateComponents
 import platform.Foundation.NSCalendar
 import platform.Foundation.NSDateFormatter
@@ -27,5 +30,21 @@ actual class DateTimeFormatter actual constructor() {
         return nsDate?.let { date ->
             formatter.stringFromDate(date)
         }
+    }
+
+    /**
+     * See commonMain documentation.
+     */
+    actual fun formatInstant(
+        instant: Instant,
+        formatPattern: String,
+        timeZone: TimeZone,
+    ): String? {
+        val localDateTime = instant.toLocalDateTime(timeZone)
+
+        return formatLocalDateTime(
+            localDateTime = localDateTime,
+            formatPattern = formatPattern,
+        )
     }
 }

--- a/core-displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventDetailDisplayModel.kt
+++ b/core-displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventDetailDisplayModel.kt
@@ -5,6 +5,7 @@ import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.EventRegion
 import com.adammcneilly.pocketleague.core.models.EventStage
 import com.adammcneilly.pocketleague.core.models.EventTier
+import kotlinx.datetime.TimeZone
 
 private const val EVENT_DATE_FORMAT = "MMM dd, yyyy"
 
@@ -33,22 +34,24 @@ fun Event.toDetailDisplayModel(): EventDetailDisplayModel {
     val dateTimeFormatter = DateTimeFormatter()
 
     return EventDetailDisplayModel(
-        startDate = this.startDate?.let { startDate ->
-            dateTimeFormatter.formatLocalDateTime(
-                localDateTime = startDate,
+        startDate = this.startDateUTC?.let { startDate ->
+            dateTimeFormatter.formatInstant(
+                instant = startDate,
                 formatPattern = EVENT_DATE_FORMAT,
+                timeZone = TimeZone.currentSystemDefault(),
             )
         }.orEmpty(),
-        endDate = this.endDate?.let { endDate ->
-            dateTimeFormatter.formatLocalDateTime(
-                localDateTime = endDate,
+        endDate = this.endDateUTC?.let { endDate ->
+            dateTimeFormatter.formatInstant(
+                instant = endDate,
                 formatPattern = EVENT_DATE_FORMAT,
+                timeZone = TimeZone.currentSystemDefault(),
             )
         }.orEmpty(),
         name = this.name,
         eventId = this.id,
         stageSummaries = this.stages.sortedBy {
-            it.startDate
+            it.startDateUTC
         }.map(EventStage::toSummaryDisplayModel),
         lightThemeImageUrl = this.imageUrl,
         tier = this.tier.toDisplayModel(),

--- a/core-displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventStageSummaryDisplayModel.kt
+++ b/core-displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventStageSummaryDisplayModel.kt
@@ -2,6 +2,7 @@ package com.adammcneilly.pocketleague.core.displaymodels
 
 import com.adammcneilly.pocketleague.core.datetime.DateTimeFormatter
 import com.adammcneilly.pocketleague.core.models.EventStage
+import kotlinx.datetime.TimeZone
 
 private const val STAGE_DATE_FORMAT = "MMM dd, yyyy"
 
@@ -28,16 +29,18 @@ fun EventStage.toSummaryDisplayModel(): EventStageSummaryDisplayModel {
     val dateTimeFormatter = DateTimeFormatter()
 
     return EventStageSummaryDisplayModel(
-        startDate = this.startDate?.let { startDate ->
-            dateTimeFormatter.formatLocalDateTime(
-                localDateTime = startDate,
+        startDate = this.startDateUTC?.let { startDate ->
+            dateTimeFormatter.formatInstant(
+                instant = startDate,
                 formatPattern = STAGE_DATE_FORMAT,
+                timeZone = TimeZone.currentSystemDefault(),
             )
         }.orEmpty(),
-        endDate = this.endDate?.let { endDate ->
-            dateTimeFormatter.formatLocalDateTime(
-                localDateTime = endDate,
+        endDate = this.endDateUTC?.let { endDate ->
+            dateTimeFormatter.formatInstant(
+                instant = endDate,
                 formatPattern = STAGE_DATE_FORMAT,
+                timeZone = TimeZone.currentSystemDefault(),
             )
         }.orEmpty(),
         stageId = this.id,

--- a/core-displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventSummaryDisplayModel.kt
+++ b/core-displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventSummaryDisplayModel.kt
@@ -2,6 +2,7 @@ package com.adammcneilly.pocketleague.core.displaymodels
 
 import com.adammcneilly.pocketleague.core.datetime.DateTimeFormatter
 import com.adammcneilly.pocketleague.core.models.Event
+import kotlinx.datetime.TimeZone
 
 private const val EVENT_DATE_FORMAT = "MMM dd, yyyy"
 
@@ -37,16 +38,18 @@ fun Event.toSummaryDisplayModel(): EventSummaryDisplayModel {
     val dateTimeFormatter = DateTimeFormatter()
 
     return EventSummaryDisplayModel(
-        startDate = this.startDate?.let { startDate ->
-            dateTimeFormatter.formatLocalDateTime(
-                localDateTime = startDate,
+        startDate = this.startDateUTC?.let { startDate ->
+            dateTimeFormatter.formatInstant(
+                instant = startDate,
                 formatPattern = EVENT_DATE_FORMAT,
+                timeZone = TimeZone.currentSystemDefault(),
             )
         }.orEmpty(),
-        endDate = this.endDate?.let { endDate ->
-            dateTimeFormatter.formatLocalDateTime(
-                localDateTime = endDate,
+        endDate = this.endDateUTC?.let { endDate ->
+            dateTimeFormatter.formatInstant(
+                instant = endDate,
                 formatPattern = EVENT_DATE_FORMAT,
+                timeZone = TimeZone.currentSystemDefault(),
             )
         }.orEmpty(),
         name = this.name,

--- a/core-displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/MatchDetailDisplayModel.kt
+++ b/core-displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/MatchDetailDisplayModel.kt
@@ -2,6 +2,7 @@ package com.adammcneilly.pocketleague.core.displaymodels
 
 import com.adammcneilly.pocketleague.core.datetime.DateTimeFormatter
 import com.adammcneilly.pocketleague.core.models.Match
+import kotlinx.datetime.TimeZone
 
 private const val MATCH_DATE_FORMAT = "MMM dd, yyyy HH:mm"
 
@@ -25,8 +26,12 @@ fun Match.toDetailDisplayModel(): MatchDetailDisplayModel {
     return MatchDetailDisplayModel(
         orangeTeamResult = this.orangeTeam.toDisplayModel(),
         blueTeamResult = this.blueTeam.toDisplayModel(),
-        date = this.date?.let { date ->
-            dateTimeFormatter.formatLocalDateTime(date, MATCH_DATE_FORMAT)
+        date = this.dateUTC?.let { date ->
+            dateTimeFormatter.formatInstant(
+                instant = date,
+                formatPattern = MATCH_DATE_FORMAT,
+                timeZone = TimeZone.currentSystemDefault(),
+            )
         }.orEmpty(),
         eventName = this.event.name,
         stageName = this.stage.name,

--- a/core-displaymodels/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventSummaryDisplayModelTest.kt
+++ b/core-displaymodels/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventSummaryDisplayModelTest.kt
@@ -2,8 +2,6 @@ package com.adammcneilly.pocketleague.core.displaymodels
 
 import com.adammcneilly.pocketleague.core.models.Event
 import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -14,8 +12,8 @@ class EventSummaryDisplayModelTest {
         val testEvent = Event(
             id = "1234",
             name = "Test Event",
-            startDateUTC = Instant.parse("2022-01-01T12:00:00Z").toLocalDateTime(TimeZone.currentSystemDefault()),
-            endDateUTC = Instant.parse("2022-01-02T12:00:00Z").toLocalDateTime(TimeZone.currentSystemDefault()),
+            startDateUTC = Instant.parse("2022-01-01T12:00:00Z"),
+            endDateUTC = Instant.parse("2022-01-02T12:00:00Z"),
             imageUrl = "Test Image URL",
         )
 

--- a/core-displaymodels/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventSummaryDisplayModelTest.kt
+++ b/core-displaymodels/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventSummaryDisplayModelTest.kt
@@ -14,8 +14,8 @@ class EventSummaryDisplayModelTest {
         val testEvent = Event(
             id = "1234",
             name = "Test Event",
-            startDate = Instant.parse("2022-01-01T12:00:00Z").toLocalDateTime(TimeZone.currentSystemDefault()),
-            endDate = Instant.parse("2022-01-02T12:00:00Z").toLocalDateTime(TimeZone.currentSystemDefault()),
+            startDateUTC = Instant.parse("2022-01-01T12:00:00Z").toLocalDateTime(TimeZone.currentSystemDefault()),
+            endDateUTC = Instant.parse("2022-01-02T12:00:00Z").toLocalDateTime(TimeZone.currentSystemDefault()),
             imageUrl = "Test Image URL",
         )
 

--- a/core-models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/Event.kt
+++ b/core-models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/Event.kt
@@ -1,6 +1,6 @@
 package com.adammcneilly.pocketleague.core.models
 
-import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Instant
 
 /**
  * Defines any Rocket League event that can occur to allow a number of teams or players
@@ -8,8 +8,8 @@ import kotlinx.datetime.LocalDateTime
  *
  * @property[id] A unique identifier for this event.
  * @property[name] The description of this event, such as "RLCS Winter Split Regional 1".
- * @property[startDate] The date that this event begins.
- * @property[endDate] The date that this event stops.
+ * @property[startDateUTC] The date that this event begins.
+ * @property[endDateUTC] The date that this event stops.
  * @property[imageUrl] The URL to the remotely hosted image for this event.
  * @property[stages] The collection of different stages that will make up this event, including qualifiers
  * and main event.
@@ -21,8 +21,8 @@ import kotlinx.datetime.LocalDateTime
 data class Event(
     val id: String = "",
     val name: String = "",
-    val startDate: LocalDateTime? = null,
-    val endDate: LocalDateTime? = null,
+    val startDateUTC: Instant? = null,
+    val endDateUTC: Instant? = null,
     val imageUrl: String? = null,
     val stages: List<EventStage> = emptyList(),
     val tier: EventTier = EventTier.Unknown,

--- a/core-models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/EventStage.kt
+++ b/core-models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/EventStage.kt
@@ -1,6 +1,6 @@
 package com.adammcneilly.pocketleague.core.models
 
-import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Instant
 
 /**
  * Defines information about a particular stage within an [Event].
@@ -8,8 +8,8 @@ import kotlinx.datetime.LocalDateTime
  * @property[id] A unique identifier for this stage.
  * @property[name] A user friendly description of the stage, such as Closed Qualifier.
  * @property[region] The region this stage applied to, like NA or EU.
- * @property[startDate] The date this stage begins.
- * @property[endDate] The date this stage will complete.
+ * @property[startDateUTC] The date this stage begins.
+ * @property[endDateUTC] The date this stage will complete.
  * @property[liquipedia] A link to the Liquipedia Wiki for this stage.
  * @property[qualifier] True if this stage is a qualifying round to a main event.
  * @property[lan] True if this stage is happening at a LAN.
@@ -18,8 +18,8 @@ data class EventStage(
     val id: String = "",
     val name: String = "",
     val region: String = "",
-    val startDate: LocalDateTime? = null,
-    val endDate: LocalDateTime? = null,
+    val startDateUTC: Instant? = null,
+    val endDateUTC: Instant? = null,
     val liquipedia: String = "",
     val qualifier: Boolean = false,
     val lan: Boolean = false,

--- a/core-models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/Match.kt
+++ b/core-models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/Match.kt
@@ -1,6 +1,6 @@
 package com.adammcneilly.pocketleague.core.models
 
-import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Instant
 
 /**
  * A [Match] is any competition between two teams. Could be a single game, a series,
@@ -9,7 +9,7 @@ import kotlinx.datetime.LocalDateTime
 data class Match(
     val id: String = "",
     val event: Event = Event(),
-    val date: LocalDateTime? = null,
+    val dateUTC: Instant? = null,
     val blueTeam: MatchTeamResult = MatchTeamResult(),
     val orangeTeam: MatchTeamResult = MatchTeamResult(),
     val stage: EventStage = EventStage(),

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/feed/LoadFeedEvent.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/feed/LoadFeedEvent.kt
@@ -23,7 +23,7 @@ fun Events.loadFeed() = screenCoroutine {
 
     val ongoingEventsRequest = EventListRequest(
         date = today,
-//        group = "rlcs",
+        group = "rlcs",
     )
 
     repository.eventRepository.fetchEvents(

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/feed/LoadFeedEvent.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/feed/LoadFeedEvent.kt
@@ -8,8 +8,6 @@ import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.shared.screens.Events
 import kotlinx.coroutines.flow.collect
 import kotlinx.datetime.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Duration.Companion.days
 
 const val NUM_DAYS_RECENT_MATCHES = 3
@@ -17,10 +15,8 @@ const val NUM_DAYS_RECENT_MATCHES = 3
  * Loads the information for the feed state.
  */
 fun Events.loadFeed() = screenCoroutine {
-    val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-
     val ongoingEventsRequest = EventListRequest(
-        date = today,
+        date = Clock.System.now(),
         group = "rlcs",
     )
 

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/feed/LoadFeedEvent.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/feed/LoadFeedEvent.kt
@@ -8,11 +8,9 @@ import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.shared.screens.Events
 import kotlinx.coroutines.flow.collect
 import kotlinx.datetime.Clock
-import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
-import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Duration.Companion.days
 
 const val NUM_DAYS_RECENT_MATCHES = 3
 /**
@@ -51,11 +49,10 @@ fun Events.loadFeed() = screenCoroutine {
     }
 
     val recentMatchesRequest = MatchListRequest(
-        before = today,
-        after = today.date.minus(NUM_DAYS_RECENT_MATCHES, DateTimeUnit.DAY)
-            .atStartOfDayIn(TimeZone.currentSystemDefault())
-            .toLocalDateTime(TimeZone.currentSystemDefault()),
-//        group = "rlcs",
+        before = Clock.System.now(),
+        after = Clock.System.now().minus(NUM_DAYS_RECENT_MATCHES.days),
+        group = "rlcs",
+        region = "NA",
     )
 
     repository.matchRepository.fetchMatches(


### PR DESCRIPTION
## Summary

* Preferring Instant over LocalDateTime as much as possible, and using the UTC suffix to ensure there's little to no confusion about a date. 

## How It Was Tested

* Manual testing.