### PR TITLE
Adding empty states on feed screen. 

### DIFF
--- a/app/src/main/java/com/adammcneilly/pocketleague/ui/FeedContent.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/ui/FeedContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -82,18 +83,31 @@ private fun SuccessContent(
             )
         }
 
-        itemsIndexed(viewState.ongoingEvents) { index, event ->
-            EventSummaryListItem(
-                displayModel = event,
-                modifier = Modifier
-                    .clickable {
-                        onEventClicked.invoke(event.eventId)
-                    }
-            )
-
-            if (index != viewState.ongoingEvents.lastIndex) {
-                Divider()
+        if (viewState.ongoingEvents.isNotEmpty()) {
+            ongoingEventsList(viewState, onEventClicked)
+        } else {
+            item {
+                OngoingEventsEmptyState()
             }
+        }
+    }
+}
+
+private fun LazyListScope.ongoingEventsList(
+    viewState: FeedViewState,
+    onEventClicked: (String) -> Unit,
+) {
+    itemsIndexed(viewState.ongoingEvents) { index, event ->
+        EventSummaryListItem(
+            displayModel = event,
+            modifier = Modifier
+                .clickable {
+                    onEventClicked.invoke(event.eventId)
+                }
+        )
+
+        if (index != viewState.ongoingEvents.lastIndex) {
+            Divider()
         }
     }
 }
@@ -102,6 +116,19 @@ private fun SuccessContent(
 private fun RecentMatchesEmptyState() {
     EmptyStateCard(
         text = stringResource(id = R.string.err_no_recent_matches),
+        modifier = Modifier
+            .padding(
+                horizontal = 16.dp,
+            ),
+        textModifier = Modifier
+            .padding(32.dp),
+    )
+}
+
+@Composable
+private fun OngoingEventsEmptyState() {
+    EmptyStateCard(
+        text = stringResource(id = R.string.err_no_ongoing_events),
         modifier = Modifier
             .padding(
                 horizontal = 16.dp,

--- a/app/src/main/java/com/adammcneilly/pocketleague/ui/FeedContent.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/ui/FeedContent.kt
@@ -15,10 +15,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.adammcneilly.pocketleague.R
 import com.adammcneilly.pocketleague.composables.eventsummary.EventSummaryListItem
 import com.adammcneilly.pocketleague.core.models.Match
 import com.adammcneilly.pocketleague.shared.screens.feed.FeedViewState
+import com.adammcneilly.pocketleague.ui.components.EmptyStateCard
 
 private const val MATCH_CARD_WIDTH_RATIO = 0.8F
 
@@ -63,22 +66,10 @@ private fun SuccessContent(
         }
 
         item {
-            LazyRow(
-                contentPadding = PaddingValues(
-                    horizontal = 16.dp,
-                ),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                items(viewState.recentMatches) { match ->
-                    RecentMatchCard(
-                        match = match,
-                        modifier = Modifier
-                            .fillParentMaxWidth(MATCH_CARD_WIDTH_RATIO)
-                            .clickable {
-                                onMatchClicked.invoke(match)
-                            },
-                    )
-                }
+            if (viewState.recentMatches.isNotEmpty()) {
+                RecentMatchesRow(viewState, onMatchClicked)
+            } else {
+                RecentMatchesEmptyState()
             }
         }
 
@@ -103,6 +94,43 @@ private fun SuccessContent(
             if (index != viewState.ongoingEvents.lastIndex) {
                 Divider()
             }
+        }
+    }
+}
+
+@Composable
+private fun RecentMatchesEmptyState() {
+    EmptyStateCard(
+        text = stringResource(id = R.string.err_no_recent_matches),
+        modifier = Modifier
+            .padding(
+                horizontal = 16.dp,
+            ),
+        textModifier = Modifier
+            .padding(32.dp),
+    )
+}
+
+@Composable
+private fun RecentMatchesRow(
+    viewState: FeedViewState,
+    onMatchClicked: (Match) -> Unit,
+) {
+    LazyRow(
+        contentPadding = PaddingValues(
+            horizontal = 16.dp,
+        ),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        items(viewState.recentMatches) { match ->
+            RecentMatchCard(
+                match = match,
+                modifier = Modifier
+                    .fillParentMaxWidth(MATCH_CARD_WIDTH_RATIO)
+                    .clickable {
+                        onMatchClicked.invoke(match)
+                    },
+            )
         }
     }
 }

--- a/app/src/main/java/com/adammcneilly/pocketleague/ui/components/EmptyStateCard.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/ui/components/EmptyStateCard.kt
@@ -1,0 +1,27 @@
+package com.adammcneilly.pocketleague.ui.components
+
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Creates a [Card] composable that renders the supplied [text]. Useful for empty and error states.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EmptyStateCard(
+    text: String,
+    modifier: Modifier = Modifier,
+    textModifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+    ) {
+        Text(
+            text = text,
+            modifier = textModifier,
+        )
+    }
+}

--- a/app/src/main/java/com/adammcneilly/pocketleague/ui/components/EmptyStateCard.kt
+++ b/app/src/main/java/com/adammcneilly/pocketleague/ui/components/EmptyStateCard.kt
@@ -1,10 +1,12 @@
 package com.adammcneilly.pocketleague.ui.components
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 
 /**
  * Creates a [Card] composable that renders the supplied [text]. Useful for empty and error states.
@@ -21,7 +23,9 @@ fun EmptyStateCard(
     ) {
         Text(
             text = text,
-            modifier = textModifier,
+            modifier = textModifier
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
     <string name="standings">Standings</string>
     <string name="standings_information_unavailable">Standings information is currently unavailable.</string>
     <string name="err_no_recent_matches">There are no recent match results.</string>
+    <string name="err_no_ongoing_events">There are no ongoing events.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="bracket_information_unavailable">Bracket information is currently unavailable.</string>
     <string name="standings">Standings</string>
     <string name="standings_information_unavailable">Standings information is currently unavailable.</string>
+    <string name="err_no_recent_matches">There are no recent match results.</string>
 </resources>


### PR DESCRIPTION
## Summary

* Adds an empty state if there are no recent matches and/or no ongoing events. 

## How It Was Tested

* Manual testing. 

## Screenshot/Gif

![image](https://user-images.githubusercontent.com/9515997/178035863-7bfceb00-3671-4fa0-ad35-b609918ea4c7.png)