### PR TITLE
Storing favorite team status in database. 

### DIFF
--- a/android/app/src/main/java/com/adammcneilly/pocketleague/ui/ScreenPicker.kt
+++ b/android/app/src/main/java/com/adammcneilly/pocketleague/ui/ScreenPicker.kt
@@ -4,12 +4,14 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.adammcneilly.pocketleague.android.designsystem.teamselection.TeamSelectionListItemClickListener
 import com.adammcneilly.pocketleague.feature.event.detail.EventDetailParams
 import com.adammcneilly.pocketleague.shared.screens.Navigation
 import com.adammcneilly.pocketleague.shared.screens.ScreenIdentifier
 import com.adammcneilly.pocketleague.shared.screens.Screens
 import com.adammcneilly.pocketleague.shared.screens.eventstagedetail.EventStageDetailParams
 import com.adammcneilly.pocketleague.shared.screens.matchdetail.MatchDetailParams
+import com.adammcneilly.pocketleague.shared.screens.myteams.updateTeamIsFavorite
 
 /**
  * The screen picker tacks a current [screenIdentifier] and renders the content for that screen.
@@ -111,6 +113,11 @@ fun Navigation.ScreenPicker(
         Screens.TeamSelection -> {
             TeamSelectionContent(
                 viewState = stateProvider.get(screenIdentifier),
+                listItemClickListener = object : TeamSelectionListItemClickListener {
+                    override fun onFavoriteChanged(teamId: String, isFavorite: Boolean) {
+                        events.updateTeamIsFavorite(teamId, isFavorite)
+                    }
+                },
                 modifier = Modifier
                     .padding(paddingValues),
             )

--- a/android/app/src/main/java/com/adammcneilly/pocketleague/ui/TeamSelectionContent.kt
+++ b/android/app/src/main/java/com/adammcneilly/pocketleague/ui/TeamSelectionContent.kt
@@ -28,7 +28,6 @@ fun TeamSelectionContent(
         itemsIndexed(teams) { index, team ->
             TeamSelectionListItem(
                 team = team,
-                isFavorite = viewState.isFavorite(team),
                 clickListener = listItemClickListener,
             )
 

--- a/android/app/src/main/java/com/adammcneilly/pocketleague/ui/TeamSelectionContent.kt
+++ b/android/app/src/main/java/com/adammcneilly/pocketleague/ui/TeamSelectionContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.adammcneilly.pocketleague.android.designsystem.teamselection.TeamSelectionListItem
+import com.adammcneilly.pocketleague.android.designsystem.teamselection.TeamSelectionListItemClickListener
 import com.adammcneilly.pocketleague.shared.screens.teamselection.TeamSelectionViewState
 
 /**
@@ -15,21 +16,20 @@ import com.adammcneilly.pocketleague.shared.screens.teamselection.TeamSelectionV
 @Composable
 fun TeamSelectionContent(
     viewState: TeamSelectionViewState,
+    listItemClickListener: TeamSelectionListItemClickListener,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
         modifier = modifier
             .fillMaxWidth(),
     ) {
-        val teams = viewState.teams.orEmpty()
+        val teams = viewState.teams
 
         itemsIndexed(teams) { index, team ->
             TeamSelectionListItem(
                 team = team,
                 isFavorite = viewState.isFavorite(team),
-                onFavoriteChanged = { isFavorite ->
-                    // Need to save this value in the future.
-                },
+                clickListener = listItemClickListener,
             )
 
             if (index != teams.lastIndex) {

--- a/android/design-system/src/main/java/com/adammcneilly/pocketleague/android/designsystem/teamselection/TeamSelectionListItem.kt
+++ b/android/design-system/src/main/java/com/adammcneilly/pocketleague/android/designsystem/teamselection/TeamSelectionListItem.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MatchingDeclarationName")
+
 package com.adammcneilly.pocketleague.android.designsystem.teamselection
 
 import androidx.compose.foundation.layout.Row
@@ -20,7 +22,6 @@ import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
  * This defines all the possible click actions that we want to expose
  * from a [TeamSelectionListItem].
  */
-@Suppress("MatchingDeclarationName")
 interface TeamSelectionListItemClickListener {
 
     /**

--- a/android/design-system/src/main/java/com/adammcneilly/pocketleague/android/designsystem/teamselection/TeamSelectionListItem.kt
+++ b/android/design-system/src/main/java/com/adammcneilly/pocketleague/android/designsystem/teamselection/TeamSelectionListItem.kt
@@ -20,6 +20,7 @@ import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
  * This defines all the possible click actions that we want to expose
  * from a [TeamSelectionListItem].
  */
+@Suppress("MatchingDeclarationName")
 interface TeamSelectionListItemClickListener {
 
     /**
@@ -35,13 +36,10 @@ interface TeamSelectionListItemClickListener {
  * Renders a list item to be used inside the team selection screen, allowing the user to change
  * whether or not this [team] is one of their favorites.
  *
- * TODO: isFavorite should not be a separate property, but
- *  stored inside our [TeamOverviewDisplayModel].
  */
 @Composable
 fun TeamSelectionListItem(
     team: TeamOverviewDisplayModel,
-    isFavorite: Boolean,
     clickListener: TeamSelectionListItemClickListener,
     modifier: Modifier = Modifier,
 ) {
@@ -62,17 +60,17 @@ fun TeamSelectionListItem(
             onClick = {
                 clickListener.onFavoriteChanged(
                     teamId = team.teamId,
-                    isFavorite = !isFavorite,
+                    isFavorite = !team.isFavorite,
                 )
             },
         ) {
             val icon = when {
-                isFavorite -> Icons.Default.Star
+                team.isFavorite -> Icons.Default.Star
                 else -> Icons.Default.StarBorder
             }
 
             val contentDescription = when {
-                isFavorite -> "Click To Remove Favorite"
+                team.isFavorite -> "Click To Remove Favorite"
                 else -> "Click To Favorite"
             }
 

--- a/android/design-system/src/main/java/com/adammcneilly/pocketleague/android/designsystem/teamselection/TeamSelectionListItem.kt
+++ b/android/design-system/src/main/java/com/adammcneilly/pocketleague/android/designsystem/teamselection/TeamSelectionListItem.kt
@@ -17,14 +17,32 @@ import androidx.compose.ui.unit.dp
 import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
 
 /**
+ * This defines all the possible click actions that we want to expose
+ * from a [TeamSelectionListItem].
+ */
+interface TeamSelectionListItemClickListener {
+
+    /**
+     * Notifies a receive that the [isFavorite] status for a given [teamId] is changed.
+     */
+    fun onFavoriteChanged(
+        teamId: String,
+        isFavorite: Boolean,
+    )
+}
+
+/**
  * Renders a list item to be used inside the team selection screen, allowing the user to change
  * whether or not this [team] is one of their favorites.
+ *
+ * TODO: isFavorite should not be a separate property, but
+ *  stored inside our [TeamOverviewDisplayModel].
  */
 @Composable
 fun TeamSelectionListItem(
     team: TeamOverviewDisplayModel,
     isFavorite: Boolean,
-    onFavoriteChanged: (Boolean) -> Unit,
+    clickListener: TeamSelectionListItemClickListener,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -42,7 +60,10 @@ fun TeamSelectionListItem(
 
         IconButton(
             onClick = {
-                onFavoriteChanged.invoke(!isFavorite)
+                clickListener.onFavoriteChanged(
+                    teamId = team.teamId,
+                    isFavorite = !isFavorite,
+                )
             },
         ) {
             val icon = when {

--- a/android/design-system/src/test/java/com/adammcneilly/pocketleague/android/designsystem/teamselection/TeamSelectionListItemPaparazziTest.kt
+++ b/android/design-system/src/test/java/com/adammcneilly/pocketleague/android/designsystem/teamselection/TeamSelectionListItemPaparazziTest.kt
@@ -23,8 +23,11 @@ class TeamSelectionListItemPaparazziTest {
         paparazzi.snapshotScreen(useDarkTheme) {
             TeamSelectionListItem(
                 team = TestDisplayModel.knights,
-                isFavorite = true,
-                onFavoriteChanged = {},
+                clickListener = object : TeamSelectionListItemClickListener {
+                    override fun onFavoriteChanged(teamId: String, isFavorite: Boolean) {
+                        TODO("Not yet implemented")
+                    }
+                },
             )
         }
     }
@@ -34,8 +37,11 @@ class TeamSelectionListItemPaparazziTest {
         paparazzi.snapshotScreen(useDarkTheme) {
             TeamSelectionListItem(
                 team = TestDisplayModel.knights,
-                isFavorite = false,
-                onFavoriteChanged = {},
+                clickListener = object : TeamSelectionListItemClickListener {
+                    override fun onFavoriteChanged(teamId: String, isFavorite: Boolean) {
+                        TODO("Not yet implemented")
+                    }
+                },
             )
         }
     }

--- a/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/TeamOverviewDisplayModel.kt
+++ b/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/TeamOverviewDisplayModel.kt
@@ -10,6 +10,7 @@ data class TeamOverviewDisplayModel(
     val name: String,
     val imageUrl: ThemedImageURL,
     val isPlaceholder: Boolean = false,
+    val isFavorite: Boolean = false,
 ) {
 
     companion object {
@@ -32,5 +33,6 @@ fun Team.toOverviewDisplayModel(): TeamOverviewDisplayModel {
         imageUrl = ThemedImageURL(
             lightThemeImageUrl = this.imageUrl,
         ),
+        isFavorite = isFavorite,
     )
 }

--- a/core/models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/Team.kt
+++ b/core/models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/Team.kt
@@ -9,4 +9,5 @@ data class Team(
     val name: String = "TBD",
     val imageUrl: String? = null,
     val isFavorite: Boolean = false,
+    val isActive: Boolean? = null,
 )

--- a/data/local-sqldelight/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/local/sqldelight/mappers/LocalTeamMappers.kt
+++ b/data/local-sqldelight/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/local/sqldelight/mappers/LocalTeamMappers.kt
@@ -9,6 +9,7 @@ fun Team.toLocalTeam(): LocalTeam {
         name = this.name,
         imageURL = this.imageUrl,
         isFavorite = this.isFavorite,
+        isActive = this.isActive,
     )
 }
 
@@ -18,5 +19,6 @@ fun LocalTeam.toTeam(): Team {
         name = this.name,
         imageUrl = this.imageURL,
         isFavorite = this.isFavorite,
+        isActive = this.isActive,
     )
 }

--- a/data/local-sqldelight/src/commonMain/sqldelight/com/adammcneilly/pocketleague/sqldelight/LocalTeam.sq
+++ b/data/local-sqldelight/src/commonMain/sqldelight/com/adammcneilly/pocketleague/sqldelight/LocalTeam.sq
@@ -2,12 +2,19 @@ CREATE TABLE localTeam(
   id TEXT NOT NULL PRIMARY KEY,
   name TEXT NOT NULL,
   imageURL TEXT,
-  isFavorite INTEGER AS Boolean NOT NULL DEFAULT 0
+  isFavorite INTEGER AS Boolean NOT NULL DEFAULT 0,
+  isActive INTEGER AS Boolean
 );
 
 selectAll:
 SELECT *
 FROM localTeam
+ORDER BY name;
+
+selectActive:
+SELECT *
+FROM localTeam
+WHERE isActive = 1
 ORDER BY name;
 
 selectFavorites:
@@ -21,13 +28,15 @@ INSERT INTO localTeam(
     id,
     name,
     imageURL,
-    isFavorite
+    isFavorite,
+    isActive
 )
 VALUES ?
 ON CONFLICT(id) DO
 UPDATE SET
     name = excluded.name,
-    imageURL = excluded.imageURL
+    imageURL = excluded.imageURL,
+    isActive = excluded.isActive
 ;
 
 setFavorite:

--- a/data/team-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/test/FakeTeamRepository.kt
+++ b/data/team-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/test/FakeTeamRepository.kt
@@ -19,6 +19,21 @@ class FakeTeamRepository : TeamRepository {
 
     private val _insertedTeams: MutableList<Team> = mutableListOf()
 
+    private val _updatedFavorites: MutableMap<String, Boolean> = mutableMapOf()
+
+    fun verifyFavoriteStatus(
+        teamId: String,
+        expectedIsFavorite: Boolean,
+    ) {
+        require(_updatedFavorites[teamId] == expectedIsFavorite)
+    }
+
+    fun verifyFavoriteStatusNotUpdated(
+        teamId: String,
+    ) {
+        require(_updatedFavorites[teamId] == null)
+    }
+
     val insertedTeams: List<Team>
         get() = _insertedTeams.toList()
 
@@ -37,6 +52,6 @@ class FakeTeamRepository : TeamRepository {
     }
 
     override suspend fun updateIsFavorite(teamId: String, isFavorite: Boolean) {
-        TODO("Not yet implemented")
+        _updatedFavorites[teamId] = isFavorite
     }
 }

--- a/data/team-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/test/FakeTeamRepository.kt
+++ b/data/team-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/test/FakeTeamRepository.kt
@@ -35,4 +35,8 @@ class FakeTeamRepository : TeamRepository {
     override suspend fun insertTeams(teams: List<Team>) {
         this._insertedTeams.addAll(teams)
     }
+
+    override suspend fun updateIsFavorite(teamId: String, isFavorite: Boolean) {
+        TODO("Not yet implemented")
+    }
 }

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OctaneGGTeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OctaneGGTeamRepository.kt
@@ -8,6 +8,7 @@ import com.adammcneilly.pocketleague.data.octanegg.models.toTeam
 import com.adammcneilly.pocketleague.data.remote.BaseKTORClient
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.isActive
 
 /**
  * A custom implementation of [TeamRepository] that will send and request data
@@ -32,7 +33,14 @@ class OctaneGGTeamRepository(
 
             // If an error occurs, we should log that.
 
-            val teamList = (apiResponse as? DataState.Success)?.data.orEmpty()
+            val teamList = (apiResponse as? DataState.Success)
+                ?.data
+                ?.map {
+                    // For any team that is requested via this API call, we want to store it
+                    // as an active team in our local data source further up this data flow.
+                    it.copy(isActive = true)
+                }
+                .orEmpty()
 
             emit(teamList)
         }

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OctaneGGTeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OctaneGGTeamRepository.kt
@@ -42,6 +42,10 @@ class OctaneGGTeamRepository(
         throw UnsupportedOperationException("Inserting teams is not supported by the octane.gg API.")
     }
 
+    override suspend fun updateIsFavorite(teamId: String, isFavorite: Boolean) {
+        throw UnsupportedOperationException("Favoriting teams is not supported by the octane.gg API.")
+    }
+
     companion object {
         const val ACTIVE_TEAMS_ENDPOINT = "/teams/active"
     }

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OfflineFirstTeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OfflineFirstTeamRepository.kt
@@ -33,4 +33,8 @@ class OfflineFirstTeamRepository(
     override suspend fun insertTeams(teams: List<Team>) {
         localDataSource.insertTeams(teams)
     }
+
+    override suspend fun updateIsFavorite(teamId: String, isFavorite: Boolean) {
+        localDataSource.updateIsFavorite(teamId, isFavorite)
+    }
 }

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/SQLDelightTeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/SQLDelightTeamRepository.kt
@@ -37,4 +37,13 @@ class SQLDelightTeamRepository(
                 .insertFullTeamObject(team.toLocalTeam())
         }
     }
+
+    override suspend fun updateIsFavorite(teamId: String, isFavorite: Boolean) {
+        database
+            .localTeamQueries
+            .setFavorite(
+                isFavorite = isFavorite,
+                id = teamId,
+            )
+    }
 }

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/SQLDelightTeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/SQLDelightTeamRepository.kt
@@ -26,7 +26,7 @@ class SQLDelightTeamRepository(
     override fun getActiveRLCSTeams(): Flow<List<Team>> {
         return database
             .localTeamQueries
-            .selectAll()
+            .selectActive()
             .asFlowList(LocalTeam::toTeam)
     }
 

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/TeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/TeamRepository.kt
@@ -23,4 +23,12 @@ interface TeamRepository {
      * Persist the supplied [teams] in the data source.
      */
     suspend fun insertTeams(teams: List<Team>)
+
+    /**
+     * Update the [teamId] to whether or not it [isFavorite] in our data source.
+     */
+    suspend fun updateIsFavorite(
+        teamId: String,
+        isFavorite: Boolean,
+    )
 }

--- a/data/team/src/commonTest/kotlin/com/adammcneilly/pocketleague/data/team/OfflineFirstTeamRepositoryTest.kt
+++ b/data/team/src/commonTest/kotlin/com/adammcneilly/pocketleague/data/team/OfflineFirstTeamRepositoryTest.kt
@@ -94,4 +94,15 @@ class OfflineFirstTeamRepositoryTest {
         assertEquals(testTeams, localDataSource.insertedTeams)
         assertEquals(emptyList(), remoteDataSource.insertedTeams)
     }
+
+    @Test
+    fun updateFavoritesOnlyCallsLocal() = runTest {
+        val teamId = "1234"
+        val isFavorite = true
+
+        repository.updateIsFavorite(teamId, isFavorite)
+
+        localDataSource.verifyFavoriteStatus(teamId, isFavorite)
+        remoteDataSource.verifyFavoriteStatusNotUpdated(teamId)
+    }
 }

--- a/data/team/src/commonTest/kotlin/com/adammcneilly/pocketleague/data/team/SQLDelightTeamRepositoryTest.kt
+++ b/data/team/src/commonTest/kotlin/com/adammcneilly/pocketleague/data/team/SQLDelightTeamRepositoryTest.kt
@@ -67,6 +67,7 @@ class SQLDelightTeamRepositoryTest {
         val teamList = List(3) {
             TestModel.team.copy(
                 id = it.toString(),
+                isActive = true,
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/myteams/LoadMyTeamsEvent.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/myteams/LoadMyTeamsEvent.kt
@@ -5,10 +5,7 @@ import com.adammcneilly.pocketleague.core.displaymodels.toOverviewDisplayModel
 import com.adammcneilly.pocketleague.core.models.DataState
 import com.adammcneilly.pocketleague.core.models.Match
 import com.adammcneilly.pocketleague.core.models.Team
-import com.adammcneilly.pocketleague.data.local.sqldelight.mappers.toTeam
-import com.adammcneilly.pocketleague.data.local.sqldelight.util.asFlowList
 import com.adammcneilly.pocketleague.shared.screens.Events
-import com.adammcneilly.pocketleague.sqldelight.LocalTeam
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -27,10 +24,8 @@ private suspend fun Events.fetchFavoriteTeams(
 ) {
     appModule
         .dataModule
-        .database
-        .localTeamQueries
-        .selectFavorites()
-        .asFlowList(LocalTeam::toTeam)
+        .teamRepository
+        .getFavoriteTeams()
         .onEach { favoriteTeamsList ->
             stateManager.updateScreen(MyTeamsViewState::class) { currentState ->
                 currentState.copy(

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/myteams/ToggleTeamIsFavoriteEvent.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/myteams/ToggleTeamIsFavoriteEvent.kt
@@ -1,0 +1,16 @@
+package com.adammcneilly.pocketleague.shared.screens.myteams
+
+import com.adammcneilly.pocketleague.shared.screens.Events
+
+/**
+ * Given a [teamId] update it's favorite status to the given [isFavorite] param.
+ */
+fun Events.updateTeamIsFavorite(
+    teamId: String,
+    isFavorite: Boolean,
+) = screenCoroutine {
+    appModule
+        .dataModule
+        .teamRepository
+        .updateIsFavorite(teamId, isFavorite)
+}

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/teamselection/LoadTeamSelectionEvent.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/teamselection/LoadTeamSelectionEvent.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.onEach
  * Load the information to populate the my teams screen.
  */
 fun Events.loadTeamSelection() = screenCoroutine {
-    fetchFavoriteTeams(it)
     fetchActiveTeams(it)
 }
 
@@ -26,25 +25,6 @@ private fun Events.fetchActiveTeams(
             stateManager.updateScreen(TeamSelectionViewState::class) { currentState ->
                 currentState.copy(
                     teams = teamList.map(Team::toOverviewDisplayModel),
-                )
-            }
-        }
-        .launchIn(scope)
-}
-
-private fun Events.fetchFavoriteTeams(
-    scope: CoroutineScope,
-) {
-    appModule
-        .dataModule
-        .teamRepository
-        .getFavoriteTeams()
-        .onEach { teamList ->
-            val displayModelList = teamList.map(Team::toOverviewDisplayModel)
-
-            stateManager.updateScreen(TeamSelectionViewState::class) { currentState ->
-                currentState.copy(
-                    favoriteTeams = displayModelList,
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/teamselection/TeamSelectionViewState.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/screens/teamselection/TeamSelectionViewState.kt
@@ -8,17 +8,7 @@ import com.adammcneilly.pocketleague.core.feature.ScreenState
  */
 data class TeamSelectionViewState(
     val teams: List<TeamOverviewDisplayModel> = emptyList(),
-    private val favoriteTeams: List<TeamOverviewDisplayModel> = emptyList(),
 ) : ScreenState {
 
     override val title: String? = null
-
-    /**
-     * Given some [team], check if a team with the same ID exists in our [favoriteTeams] list.
-     */
-    fun isFavorite(team: TeamOverviewDisplayModel): Boolean {
-        return favoriteTeams.any { favoriteTeam ->
-            favoriteTeam.teamId == team.teamId
-        }
-    }
 }


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Storing favorite & active status in our database, and updating the relevant screens and data layers to allow the user to mark a team as favorite, and see it within the `My Teams` screen. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

Added one unit test, mostly manual testing.

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->

<details>

<summary>My Teams Screen</summary>
    
![FavoriteTeamsScreen](https://user-images.githubusercontent.com/9515997/210680547-c48ed53f-8fee-40d9-9d4a-ec5702069d92.png)


</details>