### PR TITLE
Providing a different navigator depending on the platform.

### DIFF
--- a/shared/app/src/androidMain/kotlin/com/adammcneilly/pocketleague/shared/app/CircuitNavigator.android.kt
+++ b/shared/app/src/androidMain/kotlin/com/adammcneilly/pocketleague/shared/app/CircuitNavigator.android.kt
@@ -1,0 +1,20 @@
+package com.adammcneilly.pocketleague.shared.app
+
+import androidx.compose.runtime.Composable
+import com.slack.circuit.backstack.SaveableBackStack
+import com.slack.circuit.foundation.rememberCircuitNavigator
+import com.slack.circuit.runtime.Navigator
+
+/**
+ * Provide an implementation of [Navigator] for the Android platform.
+ */
+@Composable
+actual fun provideCircuitNavigator(
+    backStack: SaveableBackStack,
+    onRootPop: () -> Unit,
+): Navigator {
+    return rememberCircuitNavigator(
+        backstack = backStack,
+        enableBackHandler = true,
+    )
+}

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/CircuitNavigator.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/CircuitNavigator.kt
@@ -1,0 +1,14 @@
+package com.adammcneilly.pocketleague.shared.app
+
+import androidx.compose.runtime.Composable
+import com.slack.circuit.backstack.SaveableBackStack
+import com.slack.circuit.runtime.Navigator
+
+/**
+ * Provide an implementation of [Navigator] with a given [backstack]
+ */
+@Composable
+expect fun provideCircuitNavigator(
+    backStack: SaveableBackStack,
+    onRootPop: () -> Unit,
+): Navigator

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/PocketLeagueApp.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/PocketLeagueApp.kt
@@ -13,7 +13,6 @@ import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.CircuitConfig
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.push
-import com.slack.circuit.foundation.rememberCircuitNavigator
 
 /**
  * Main composable entrypoint to the shared multiplatform version of
@@ -38,7 +37,7 @@ fun PocketLeagueApp(
                 push(FeedScreen)
             }
 
-            val navigator = rememberCircuitNavigator(backstack) {
+            val navigator = provideCircuitNavigator(backstack) {
                 println("Is this being called?")
                 // In the future, we need to handle a back press when we are at the root
                 // screen (probably just close the app?)

--- a/shared/app/src/iosMain/kotlin/com/adammcneilly/pocketleague/shared/app/CircuitNavigator.ios.kt
+++ b/shared/app/src/iosMain/kotlin/com/adammcneilly/pocketleague/shared/app/CircuitNavigator.ios.kt
@@ -1,0 +1,20 @@
+package com.adammcneilly.pocketleague.shared.app
+
+import androidx.compose.runtime.Composable
+import com.slack.circuit.backstack.SaveableBackStack
+import com.slack.circuit.foundation.rememberCircuitNavigator
+import com.slack.circuit.runtime.Navigator
+
+/**
+ * Provide an implementation of [Navigator] for the iOS platform.
+ */
+@Composable
+actual fun provideCircuitNavigator(
+    backStack: SaveableBackStack,
+    onRootPop: () -> Unit,
+): Navigator {
+    return rememberCircuitNavigator(
+        backstack = backStack,
+        onRootPop = onRootPop,
+    )
+}


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

By using an Android specific navigator, we can leverage the system back press. Not sure how to do the same on iOS yet. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

Manually tested pressing back with system button. 
