### PR TITLE
Adding Dialog composable for iOS & Android

### DIFF
--- a/android/app/src/main/java/com/adammcneilly/pocketleague/ui/GameDetailDialog.kt
+++ b/android/app/src/main/java/com/adammcneilly/pocketleague/ui/GameDetailDialog.kt
@@ -3,6 +3,7 @@ package com.adammcneilly.pocketleague.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.window.Dialog
 import com.adammcneilly.pocketleague.core.displaymodels.GameDetailDisplayModel
+import com.adammcneilly.pocketleague.shared.ui.game.GameDetailContent
 
 /**
  * Renders a [GameDetailContent] composable inside a dialog.

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailPresenter.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailPresenter.kt
@@ -38,6 +38,10 @@ class MatchDetailPresenter(
             )
         }
 
+        var selectedGame by remember {
+            mutableStateOf<GameDetailDisplayModel?>(null)
+        }
+
         LaunchedEffect(Unit) {
             match = OctaneGGMatchService()
                 .getMatchDetail(matchId)
@@ -54,11 +58,16 @@ class MatchDetailPresenter(
 
         return MatchDetailScreen.State(
             match = match,
+            selectedGame = selectedGame,
             games = games,
         ) { event ->
             when (event) {
-                // No events yet
-                else -> {}
+                is MatchDetailScreen.Event.GameSelected -> {
+                    selectedGame = event.game
+                }
+                MatchDetailScreen.Event.SelectedGameDismissed -> {
+                    selectedGame = null
+                }
             }
         }
     }

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailScreen.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailScreen.kt
@@ -26,13 +26,27 @@ data class MatchDetailScreen(
     data class State(
         val match: MatchDetailDisplayModel,
         val games: List<GameDetailDisplayModel>,
+        val selectedGame: GameDetailDisplayModel?,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 
     /**
      * Any events that can be triggered by the [MatchDetailScreen].
      */
-    sealed interface Event : CircuitUiEvent
+    sealed interface Event : CircuitUiEvent {
+
+        /**
+         * Triggered when a user clicks on a specific game from the list.
+         */
+        data class GameSelected(
+            val game: GameDetailDisplayModel,
+        ) : Event
+
+        /**
+         * Triggered whenever the user dismisses the currently selected game dialog.
+         */
+        object SelectedGameDismissed : Event
+    }
 
     /**
      * Factory to create the compose UI for the [MatchDetailScreen].
@@ -45,10 +59,18 @@ data class MatchDetailScreen(
                         MatchDetailContent(
                             match = state.match,
                             games = state.games,
+                            selectedGame = state.selectedGame,
+                            onSelectedGameDismissed = {
+                                state.eventSink.invoke(Event.SelectedGameDismissed)
+                            },
+                            onGameClicked = { game ->
+                                state.eventSink.invoke(Event.GameSelected(game))
+                            },
                             modifier = modifier,
                         )
                     }
                 }
+
                 else -> null
             }
         }
@@ -63,6 +85,7 @@ data class MatchDetailScreen(
                 is MatchDetailScreen -> MatchDetailPresenter(
                     matchId = screen.matchId,
                 )
+
                 else -> null
             }
         }

--- a/shared/ui/src/androidMain/kotlin/com/adammcneilly/pocketleague/shared/ui/components/Dialog.android.kt
+++ b/shared/ui/src/androidMain/kotlin/com/adammcneilly/pocketleague/shared/ui/components/Dialog.android.kt
@@ -1,0 +1,22 @@
+package com.adammcneilly.pocketleague.shared.ui.components
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Android implementation of a Dialog.
+ */
+@Composable
+actual fun Dialog(
+    onDismissRequest: () -> Unit,
+    properties: DialogProperties,
+    content: @Composable () -> Unit,
+) {
+    androidx.compose.ui.window.Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = androidx.compose.ui.window.DialogProperties(
+            dismissOnBackPress = properties.dismissOnBackPress,
+            dismissOnClickOutside = properties.dismissOnClickOutside,
+        ),
+        content = content,
+    )
+}

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/components/Dialog.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/components/Dialog.kt
@@ -1,0 +1,25 @@
+package com.adammcneilly.pocketleague.shared.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+
+/**
+ * A Dialog is a piece of UI that appears on top of everything else
+ * on the screen.
+ */
+@Composable
+expect fun Dialog(
+    onDismissRequest: () -> Unit,
+    properties: DialogProperties,
+    content: @Composable () -> Unit,
+)
+
+/**
+ * Properties of a [Dialog] that configure certain properties we care about. Matches the same
+ * properties set in an Android dialog by default.
+ */
+@Immutable
+data class DialogProperties(
+    val dismissOnBackPress: Boolean = true,
+    val dismissOnClickOutside: Boolean = true,
+)

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameDetailContent.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameDetailContent.kt
@@ -1,4 +1,4 @@
-package com.adammcneilly.pocketleague.ui
+package com.adammcneilly.pocketleague.shared.ui.game
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -17,7 +17,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.adammcneilly.pocketleague.core.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pocketleague.shared.ui.components.InlineIconText
-import com.adammcneilly.pocketleague.ui.composables.stats.PlayerStatsTable
+import com.adammcneilly.pocketleague.shared.ui.stats.PlayerStatsTable
 
 /**
  * Renders a [displayModel] to show detailed information about a game.

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameDetailDialog.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameDetailDialog.kt
@@ -11,9 +11,10 @@ import com.adammcneilly.pocketleague.shared.ui.components.DialogProperties
 @Composable
 fun GameDetailDialog(
     game: GameDetailDisplayModel,
+    onDismissRequest: () -> Unit,
 ) {
     Dialog(
-        onDismissRequest = {},
+        onDismissRequest = onDismissRequest,
         properties = DialogProperties(),
     ) {
         GameDetailContent(game)

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameDetailDialog.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameDetailDialog.kt
@@ -5,6 +5,9 @@ import com.adammcneilly.pocketleague.core.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pocketleague.shared.ui.components.Dialog
 import com.adammcneilly.pocketleague.shared.ui.components.DialogProperties
 
+/**
+ * A [Dialog] component to render detailed information about a given [game].
+ */
 @Composable
 fun GameDetailDialog(
     game: GameDetailDisplayModel,

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameDetailDialog.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameDetailDialog.kt
@@ -1,0 +1,18 @@
+package com.adammcneilly.pocketleague.shared.ui.game
+
+import androidx.compose.runtime.Composable
+import com.adammcneilly.pocketleague.core.displaymodels.GameDetailDisplayModel
+import com.adammcneilly.pocketleague.shared.ui.components.Dialog
+import com.adammcneilly.pocketleague.shared.ui.components.DialogProperties
+
+@Composable
+fun GameDetailDialog(
+    game: GameDetailDisplayModel,
+) {
+    Dialog(
+        onDismissRequest = {},
+        properties = DialogProperties(),
+    ) {
+        GameDetailContent(game)
+    }
+}

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameListCard.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameListCard.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.shared.ui.game
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Card
 import androidx.compose.material3.Divider
@@ -13,6 +14,7 @@ import com.adammcneilly.pocketleague.core.displaymodels.GameDetailDisplayModel
 @Composable
 fun GameListCard(
     games: List<GameDetailDisplayModel>,
+    onGameClicked: (GameDetailDisplayModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -20,7 +22,13 @@ fun GameListCard(
     ) {
         Column {
             games.forEachIndexed { index, game ->
-                GameListItem(game)
+                GameListItem(
+                    displayModel = game,
+                    modifier = Modifier
+                        .clickable {
+                            onGameClicked.invoke(game)
+                        },
+                )
 
                 if (index != games.lastIndex) {
                     Divider()

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/match/MatchDetailContent.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/match/MatchDetailContent.kt
@@ -23,12 +23,16 @@ import com.adammcneilly.pocketleague.shared.ui.stats.CoreStatsComparisonCard
 fun MatchDetailContent(
     match: MatchDetailDisplayModel,
     games: List<GameDetailDisplayModel>,
+    selectedGame: GameDetailDisplayModel?,
+    onSelectedGameDismissed: () -> Unit,
+    onGameClicked: (GameDetailDisplayModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    games.firstOrNull()?.let { game ->
-        if (!game.isPlaceholder) {
-            GameDetailDialog(game)
-        }
+    if (selectedGame != null) {
+        GameDetailDialog(
+            game = selectedGame,
+            onDismissRequest = onSelectedGameDismissed,
+        )
     }
 
     LazyColumn(
@@ -39,7 +43,7 @@ fun MatchDetailContent(
     ) {
         matchDetailHeader(match)
 
-        gamesSection(games)
+        gamesSection(games, onGameClicked)
 
         statsSection(match)
     }
@@ -65,10 +69,13 @@ private fun LazyListScope.statsSection(match: MatchDetailDisplayModel) {
     }
 }
 
-private fun LazyListScope.gamesSection(games: List<GameDetailDisplayModel>) {
+private fun LazyListScope.gamesSection(
+    games: List<GameDetailDisplayModel>,
+    onGameClicked: (GameDetailDisplayModel) -> Unit,
+) {
     gamesHeader()
 
-    gamesList(games)
+    gamesList(games, onGameClicked)
 }
 
 private fun LazyListScope.gamesHeader() {
@@ -79,10 +86,14 @@ private fun LazyListScope.gamesHeader() {
     }
 }
 
-private fun LazyListScope.gamesList(games: List<GameDetailDisplayModel>) {
+private fun LazyListScope.gamesList(
+    games: List<GameDetailDisplayModel>,
+    onGameClicked: (GameDetailDisplayModel) -> Unit,
+) {
     item {
         GameListCard(
             games = games,
+            onGameClicked = onGameClicked,
         )
     }
 }

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/match/MatchDetailContent.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/match/MatchDetailContent.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import com.adammcneilly.pocketleague.core.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.MatchDetailDisplayModel
 import com.adammcneilly.pocketleague.shared.design.system.theme.PocketLeagueTheme
+import com.adammcneilly.pocketleague.shared.ui.game.GameDetailDialog
 import com.adammcneilly.pocketleague.shared.ui.game.GameListCard
 import com.adammcneilly.pocketleague.shared.ui.stats.CoreStatsComparisonCard
 
@@ -24,6 +25,12 @@ fun MatchDetailContent(
     games: List<GameDetailDisplayModel>,
     modifier: Modifier = Modifier,
 ) {
+    games.firstOrNull()?.let { game ->
+        if (!game.isPlaceholder) {
+            GameDetailDialog(game)
+        }
+    }
+
     LazyColumn(
         modifier = modifier
             .fillMaxSize(),

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/stats/PlayerStatsTable.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/stats/PlayerStatsTable.kt
@@ -1,4 +1,4 @@
-package com.adammcneilly.pocketleague.ui.composables.stats
+package com.adammcneilly.pocketleague.shared.ui.stats
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Divider

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/stats/StatTableRow.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/stats/StatTableRow.kt
@@ -1,4 +1,4 @@
-package com.adammcneilly.pocketleague.ui.composables.stats
+package com.adammcneilly.pocketleague.shared.ui.stats
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row

--- a/shared/ui/src/iosMain/kotlin/com/adammcneilly/pocketleague/shared/ui/components/Dialog.ios.kt
+++ b/shared/ui/src/iosMain/kotlin/com/adammcneilly/pocketleague/shared/ui/components/Dialog.ios.kt
@@ -112,6 +112,7 @@ private fun DialogBackground(
 }
 
 @Composable
+@Suppress("MagicNumber")
 private fun DialogContent(
     visible: Boolean,
     content: @Composable () -> Unit,

--- a/shared/ui/src/iosMain/kotlin/com/adammcneilly/pocketleague/shared/ui/components/Dialog.ios.kt
+++ b/shared/ui/src/iosMain/kotlin/com/adammcneilly/pocketleague/shared/ui/components/Dialog.ios.kt
@@ -1,0 +1,143 @@
+package com.adammcneilly.pocketleague.shared.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DrawerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import com.adammcneilly.pocketleague.shared.design.system.theme.PocketLeagueTheme
+import org.jetbrains.skiko.SkikoKey
+
+/**
+ * An iOS implementation of a Dialog.
+ *
+ * Mostly copied from: https://github.com/chrisbanes/tivi/blob/main/common/ui/compose/src/iosMain/kotlin/app/tivi/common/compose/Dialog.kt
+ */
+@Composable
+actual fun Dialog(
+    onDismissRequest: () -> Unit,
+    properties: DialogProperties,
+    content: @Composable () -> Unit,
+) {
+    Popup(
+        onDismissRequest = onDismissRequest,
+        popupPositionProvider = IosPopupPositionProvider,
+        focusable = true,
+        onKeyEvent = { event ->
+            if (properties.dismissOnBackPress && event.type == KeyEventType.KeyDown &&
+                event.nativeKeyEvent.key == SkikoKey.KEY_ESCAPE
+            ) {
+                onDismissRequest()
+                true
+            } else {
+                false
+            }
+        },
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            var visible by remember { mutableStateOf(false) }
+
+            LaunchedEffect(Unit) {
+                visible = true
+            }
+
+            DialogBackground(
+                visible = visible,
+                properties = properties,
+                onDismissRequest = onDismissRequest,
+            )
+
+            DialogContent(
+                visible = visible,
+                content = content,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DialogBackground(
+    visible: Boolean,
+    properties: DialogProperties,
+    onDismissRequest: () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(DrawerDefaults.scrimColor)
+                .let { modifier ->
+                    if (properties.dismissOnClickOutside) {
+                        modifier.pointerInput(onDismissRequest) {
+                            detectTapGestures(onTap = { onDismissRequest() })
+                        }
+                    } else {
+                        modifier
+                    }
+                },
+        )
+    }
+}
+
+@Composable
+private fun DialogContent(
+    visible: Boolean,
+    content: @Composable () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = slideInVertically(initialOffsetY = { it / 6 }) + fadeIn(),
+        exit = slideOutVertically(targetOffsetY = { it / 6 }) + fadeOut(),
+        modifier = Modifier
+            .padding(PocketLeagueTheme.sizes.screenPadding),
+    ) {
+        content()
+    }
+}
+
+/**
+ * An implementation of a [PopupPositionProvider] that just returns [IntOffset.Zero]. This is because our
+ * popup basically takes up the whole screen (the background tint) and so we don't need to offset this popup.
+ *
+ * If we wanted to use something like a menu dropdown or tooltip, we would offset based on the item clicked.
+ */
+private object IosPopupPositionProvider : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset = IntOffset.Zero
+}

--- a/shared/ui/src/test/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameListCardPaparazziTest.kt
+++ b/shared/ui/src/test/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameListCardPaparazziTest.kt
@@ -27,6 +27,7 @@ class GameListCardPaparazziTest {
         paparazzi.snapshotScreen(useDarkTheme) {
             GameListCard(
                 games = games,
+                onGameClicked = {},
             )
         }
     }
@@ -38,6 +39,7 @@ class GameListCardPaparazziTest {
         paparazzi.snapshotScreen(useDarkTheme) {
             GameListCard(
                 games = games,
+                onGameClicked = {},
             )
         }
     }

--- a/shared/ui/src/test/kotlin/com/adammcneilly/pocketleague/shared/ui/match/MatchDetailContentPaparazziTest.kt
+++ b/shared/ui/src/test/kotlin/com/adammcneilly/pocketleague/shared/ui/match/MatchDetailContentPaparazziTest.kt
@@ -31,6 +31,9 @@ class MatchDetailContentPaparazziTest {
             MatchDetailContent(
                 match = TestDisplayModel.matchDetailBlueWinner,
                 games = GameDetailDisplayModel.variations(),
+                selectedGame = null,
+                onSelectedGameDismissed = {},
+                onGameClicked = {},
             )
         }
     }
@@ -44,6 +47,9 @@ class MatchDetailContentPaparazziTest {
             MatchDetailContent(
                 match = MatchDetailDisplayModel.placeholder,
                 games = GameDetailDisplayModel.placeholders(),
+                selectedGame = null,
+                onSelectedGameDismissed = {},
+                onGameClicked = {},
             )
         }
     }


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

On Android, using default component. On iOS, using a custom written pop up. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

Manually tested on each platform. 

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->

<details>

<summary>Android Dialog</summary>
    
![AndroidDialog](https://github.com/AdamMc331/PocketLeague/assets/9515997/95b09409-4401-49fd-a8ff-3176228d76d4)


</details>

<details>

<summary>iOS Dialog</summary>
    
![Simulator Screen Shot - iPhone 14 Pro - 2023-07-13 at 19 19 44](https://github.com/AdamMc331/PocketLeague/assets/9515997/304ef98c-8264-44c7-b5ca-4056cd69863a)



</details>