### PR TITLE
Adding DebugClock and removing hardcoded references to Clock.System.

### DIFF
--- a/core/datetime/build.gradle.kts
+++ b/core/datetime/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(libs.varabyte.truthish)
             }
         }
         val jvmMain by getting

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateUtils.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateUtils.kt
@@ -32,6 +32,10 @@ object DateUtils {
         utcString: String,
         clock: Clock = Clock.System,
     ): String {
+        require(isBeforeNow(utcString, clock)) {
+            "getRelativeTimestamp only valid for past dates."
+        }
+
         val instant = Instant.parse(utcString)
 
         val now = clock.now()
@@ -40,7 +44,7 @@ object DateUtils {
 
         return when {
             duration.inWholeMinutes < MINUTES_IN_HOUR -> {
-                "${duration.inWholeDays}m ago"
+                "${duration.inWholeMinutes}m ago"
             }
             duration.inWholeHours < HOURS_IN_DAY -> {
                 "${duration.inWholeHours}h ago"

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateUtils.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateUtils.kt
@@ -16,19 +16,25 @@ object DateUtils {
      * Determines if the date represented by the supplied [utcString]
      * occurred before the current date.
      */
-    fun isBeforeNow(utcString: String): Boolean {
+    fun isBeforeNow(
+        utcString: String,
+        clock: Clock = Clock.System,
+    ): Boolean {
         val instant = Instant.parse(utcString)
 
-        return instant < Clock.System.now()
+        return instant < clock.now()
     }
 
     /**
-     * Given an [instant], convert it to a relative timestamp such as 5m ago, or 5d ago.
+     * Given a [utcString], convert it to a relative timestamp such as 5m ago, or 5d ago.
      */
-    fun getRelativeTimestamp(utcString: String): String {
+    fun getRelativeTimestamp(
+        utcString: String,
+        clock: Clock = Clock.System,
+    ): String {
         val instant = Instant.parse(utcString)
 
-        val now = Clock.System.now()
+        val now = clock.now()
 
         val duration = now.minus(instant)
 

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugClock.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugClock.kt
@@ -8,9 +8,11 @@ import kotlinx.datetime.Instant
  *
  * Allows us to test the app at any given point in time.
  */
-class DebugClock : Clock {
+class DebugClock(
+    private val dateString: String = "2023-07-08T12:00:00Z",
+) : Clock {
 
     override fun now(): Instant {
-        return Instant.parse("2023-07-08T12:00:00Z")
+        return Instant.parse(dateString)
     }
 }

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugClock.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugClock.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.Instant
  * Allows us to test the app at any given point in time.
  */
 class DebugClock(
-    private val dateString: String = "2023-07-08T12:00:00Z",
+    private val dateString: String = "2023-07-08T16:00:00Z",
 ) : Clock {
 
     override fun now(): Instant {

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugClock.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugClock.kt
@@ -1,0 +1,16 @@
+package com.adammcneilly.pocketleague.core.datetime
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Custom implementation of a [Clock] to hardcode a specific date.
+ *
+ * Allows us to test the app at any given point in time.
+ */
+class DebugClock : Clock {
+
+    override fun now(): Instant {
+        return Instant.parse("2023-07-08T12:00:00Z")
+    }
+}

--- a/core/datetime/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/datetime/DateUtilsTest.kt
+++ b/core/datetime/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/datetime/DateUtilsTest.kt
@@ -1,0 +1,91 @@
+package com.adammcneilly.pocketleague.core.datetime
+
+import com.varabyte.truthish.assertThat
+import com.varabyte.truthish.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DateUtilsTest {
+
+    @Test
+    fun `isBeforeNow returns true for past date`() {
+        val pastDate = "2023-07-18T12:00:00Z"
+        val now = "2024-07-18T12:00:00Z"
+
+        val clock = DebugClock(now)
+
+        assertTrue(DateUtils.isBeforeNow(pastDate, clock))
+    }
+
+    @Test
+    fun `isBeforeNow returns false for future date`() {
+        val futureDate = "2023-07-18T12:00:00Z"
+        val now = "2022-07-18T12:00:00Z"
+
+        val clock = DebugClock(now)
+
+        assertFalse(DateUtils.isBeforeNow(futureDate, clock))
+    }
+
+    @Test
+    fun `isBeforeNow returns false for same date`() {
+        val now = "2022-07-18T12:00:00Z"
+
+        val clock = DebugClock(now)
+
+        assertFalse(DateUtils.isBeforeNow(now, clock))
+    }
+
+    @Test
+    fun `getRelativeTimestamp within minutes`() {
+        val pastDate = "2023-07-18T11:55:00Z"
+        val now = "2023-07-18T12:00:00Z"
+
+        val clock = DebugClock(now)
+
+        assertThat("5m ago").isEqualTo(DateUtils.getRelativeTimestamp(pastDate, clock))
+    }
+
+    @Test
+    fun `getRelativeTimestamp within hours`() {
+        val pastDate = "2023-07-18T05:55:00Z"
+        val now = "2023-07-18T12:00:00Z"
+
+        val clock = DebugClock(now)
+
+        assertThat("6h ago").isEqualTo(DateUtils.getRelativeTimestamp(pastDate, clock))
+    }
+
+    @Test
+    fun `getRelativeTimestamp within days`() {
+        val pastDate = "2023-07-12T11:55:00Z"
+        val now = "2023-07-18T12:00:00Z"
+
+        val clock = DebugClock(now)
+
+        assertThat("6d ago").isEqualTo(DateUtils.getRelativeTimestamp(pastDate, clock))
+    }
+
+    @Test
+    fun `getRelativeTimestamp within years`() {
+        val pastDate = "2022-07-18T11:55:00Z"
+        val now = "2023-07-18T12:00:00Z"
+
+        val clock = DebugClock(now)
+
+        assertThat("365d ago").isEqualTo(DateUtils.getRelativeTimestamp(pastDate, clock))
+    }
+
+    @Test
+    fun `getRelativeTimestamp throws in future`() {
+        val futureDate = "2024-07-18T11:55:00Z"
+        val now = "2023-07-18T12:00:00Z"
+
+        val clock = DebugClock(now)
+
+        assertThrows<IllegalArgumentException> {
+            DateUtils.getRelativeTimestamp(futureDate, clock)
+        }
+    }
+}

--- a/data/event/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/event/OctaneGGEventService.kt
+++ b/data/event/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/event/OctaneGGEventService.kt
@@ -17,15 +17,16 @@ import kotlinx.datetime.Clock
  */
 class OctaneGGEventService(
     private val apiClient: BaseKTORClient,
+    private val clock: Clock,
 ) : RemoteEventService {
 
-    constructor() : this(OctaneGGAPIClient)
+    constructor() : this(OctaneGGAPIClient, Clock.System)
 
     override suspend fun getUpcomingEvents(): Result<List<Event>> {
         return apiClient.getResponse<OctaneGGEventListResponse>(
             endpoint = EVENTS_ENDPOINT,
             params = mapOf(
-                "after" to Clock.System.now().toString(),
+                "after" to clock.now().toString(),
                 "group" to "rlcs",
             ),
         ).map { eventListResponse ->
@@ -59,7 +60,7 @@ class OctaneGGEventService(
         return apiClient.getResponse<OctaneGGEventListResponse>(
             endpoint = EVENTS_ENDPOINT,
             params = mapOf(
-                "date" to Clock.System.now().toString(),
+                "date" to clock.now().toString(),
                 "group" to "rlcs",
             ),
         ).map { eventListResponse ->

--- a/data/match/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/OctaneGGMatchService.kt
+++ b/data/match/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/OctaneGGMatchService.kt
@@ -15,9 +15,10 @@ import kotlin.time.Duration.Companion.days
  */
 class OctaneGGMatchService(
     private val apiClient: BaseKTORClient,
+    private val clock: Clock,
 ) : RemoteMatchService {
 
-    constructor() : this(OctaneGGAPIClient)
+    constructor() : this(OctaneGGAPIClient, Clock.System)
 
     override suspend fun getMatchDetail(matchId: String): Result<Match> {
         return apiClient.getResponse<OctaneGGMatch>(
@@ -31,8 +32,8 @@ class OctaneGGMatchService(
         return apiClient.getResponse<OctaneGGMatchListResponse>(
             endpoint = MATCHES_ENDPOINT,
             params = mapOf(
-                "before" to Clock.System.now(),
-                "after" to Clock.System.now().minus(NUM_DAYS_RECENT_MATCHES.days),
+                "before" to clock.now(),
+                "after" to clock.now().minus(NUM_DAYS_RECENT_MATCHES.days),
                 "group" to "rlcs",
             ),
         ).map { octaneMatchListResponse ->
@@ -47,7 +48,7 @@ class OctaneGGMatchService(
         return apiClient.getResponse<OctaneGGMatchListResponse>(
             endpoint = MATCHES_ENDPOINT,
             params = mapOf(
-                "after" to Clock.System.now(),
+                "after" to clock.now(),
                 "group" to "rlcs",
             ),
         ).map { octaneMatchListResponse ->


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Allows us to specify a special time in the app, super useful for debugging PocketLeague and looking at how the app would work on a given date. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

Manually tested by replacing reference with DebugClock. See screenshot section. 

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->

<details>

<summary>During Spring Major</summary>
    
![DuringSpringMajor](https://github.com/AdamMc331/PocketLeague/assets/9515997/d9e03524-0404-4dba-b9ed-886b73331d3c)

</details>

<details>

<summary>During Regionals</summary>
    
![DuringRegionals](https://github.com/AdamMc331/PocketLeague/assets/9515997/604f7366-ab51-414e-9684-20f2472ff68c)

</details>