### PR TITLE
Implementing header & roster card on team detail. 

### DIFF
--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DefaultClock.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DefaultClock.kt
@@ -8,4 +8,4 @@ import kotlinx.datetime.Clock
  * Utility function makes this easy to swap in a [DebugClock] when we want
  * to test.
  */
-fun defaultClock(): Clock = DebugClock()
+fun defaultClock(): Clock = Clock.System // DebugClock()

--- a/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestDisplayModel.kt
+++ b/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestDisplayModel.kt
@@ -9,6 +9,8 @@ import com.adammcneilly.pocketleague.core.displaymodels.MatchTeamResultDisplayMo
 import com.adammcneilly.pocketleague.core.displaymodels.PlayerDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.ThemedImageURL
+import com.adammcneilly.pocketleague.core.displaymodels.toDisplayModel
+import com.adammcneilly.pocketleague.core.models.EventRegion
 import com.adammcneilly.pocketleague.core.models.EventStage
 import com.adammcneilly.pocketleague.core.models.Match
 import com.adammcneilly.pocketleague.core.models.StageRound
@@ -44,7 +46,7 @@ object TestDisplayModel {
 //            lightThemeImageURL = "https://griffon.octane.gg/teams/pittsburgh-knights.png",
 //        ),
         imageUrl = ThemedImageURL(),
-        region = "North America",
+        region = EventRegion.NA.toDisplayModel(),
     )
 
     val g2 = TeamOverviewDisplayModel(
@@ -54,7 +56,7 @@ object TestDisplayModel {
 //            lightThemeImageURL = "https://griffon.octane.gg/teams/g2-esports.png",
 //        ),
         imageUrl = ThemedImageURL(),
-        region = "North America",
+        region = EventRegion.NA.toDisplayModel(),
     )
 
     val matchTeamResultWinner = MatchTeamResultDisplayModel(

--- a/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestDisplayModel.kt
+++ b/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestDisplayModel.kt
@@ -44,7 +44,7 @@ object TestDisplayModel {
 //            lightThemeImageURL = "https://griffon.octane.gg/teams/pittsburgh-knights.png",
 //        ),
         imageUrl = ThemedImageURL(),
-        regionName = "North America",
+        region = "North America",
     )
 
     val g2 = TeamOverviewDisplayModel(
@@ -54,7 +54,7 @@ object TestDisplayModel {
 //            lightThemeImageURL = "https://griffon.octane.gg/teams/g2-esports.png",
 //        ),
         imageUrl = ThemedImageURL(),
-        regionName = "North America",
+        region = "North America",
     )
 
     val matchTeamResultWinner = MatchTeamResultDisplayModel(

--- a/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestTeamOverviewDisplayModel.kt
+++ b/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestTeamOverviewDisplayModel.kt
@@ -2,6 +2,8 @@ package com.adammcneilly.pocketleague.core.displaymodels.test
 
 import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.ThemedImageURL
+import com.adammcneilly.pocketleague.core.displaymodels.toDisplayModel
+import com.adammcneilly.pocketleague.core.models.EventRegion
 
 /**
  * Creates a test implementation of [TeamOverviewDisplayModel] for Team Vitality.
@@ -11,6 +13,6 @@ fun TeamOverviewDisplayModel.Companion.teamVitality(): TeamOverviewDisplayModel 
         teamId = "vitalityId",
         name = "Team Vitality",
         imageUrl = ThemedImageURL(),
-        region = "Europe",
+        region = EventRegion.EU.toDisplayModel(),
     )
 }

--- a/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestTeamOverviewDisplayModel.kt
+++ b/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestTeamOverviewDisplayModel.kt
@@ -11,6 +11,6 @@ fun TeamOverviewDisplayModel.Companion.teamVitality(): TeamOverviewDisplayModel 
         teamId = "vitalityId",
         name = "Team Vitality",
         imageUrl = ThemedImageURL(),
-        regionName = "Europe",
+        region = "Europe",
     )
 }

--- a/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventRegionDisplayModel.kt
+++ b/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventRegionDisplayModel.kt
@@ -7,47 +7,18 @@ import com.adammcneilly.pocketleague.core.models.EventRegion
  */
 data class EventRegionDisplayModel(
     val name: String,
-    val description: String,
 )
 
 /**
  * Converts a [EventRegion] to a relevant [EventRegionDisplayModel].
  */
 fun EventRegion.toDisplayModel(): EventRegionDisplayModel {
-    val name = "Region: ${this.name}"
-
-    val description = when (this) {
-        EventRegion.NA -> {
-            "This event takes place in North America."
-        }
-        EventRegion.EU -> {
-            "This event takes place in Europe."
-        }
-        EventRegion.OCE -> {
-            "This event takes place in Oceania."
-        }
-        EventRegion.SAM -> {
-            "This event takes place in South America."
-        }
-        EventRegion.APAC -> {
-            "Ths event takes place in Asia."
-        }
-        EventRegion.MENA -> {
-            "This event takes place in the Middle East."
-        }
-        EventRegion.INT -> {
-            "This event takes place internationally."
-        }
-        EventRegion.Unknown -> {
-            "The region of this event is unreported."
-        }
-        EventRegion.SSA -> {
-            "This event takes place in Sub-Saharan Africa."
-        }
-    }
+    // In a perfect world, we would have a when statement here to convert each region
+    // into a localized string, but for now we can just leverage
+    // the fact that the liquipediaRegionKey is a user friendly representation of the region's name.
+    val name = this.liquipediaRegionKey
 
     return EventRegionDisplayModel(
         name = name,
-        description = description,
     )
 }

--- a/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/TeamOverviewDisplayModel.kt
+++ b/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/TeamOverviewDisplayModel.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.core.displaymodels
 
+import com.adammcneilly.pocketleague.core.models.EventRegion
 import com.adammcneilly.pocketleague.core.models.Team
 
 /**
@@ -9,7 +10,7 @@ data class TeamOverviewDisplayModel(
     val teamId: String,
     val name: String,
     val imageUrl: ThemedImageURL,
-    val regionName: String,
+    val region: EventRegionDisplayModel,
     val isPlaceholder: Boolean = false,
     val isFavorite: Boolean = false,
 ) {
@@ -20,7 +21,7 @@ data class TeamOverviewDisplayModel(
             name = "",
             imageUrl = ThemedImageURL(),
             isPlaceholder = true,
-            regionName = "",
+            region = EventRegion.Unknown.toDisplayModel(),
         )
     }
 }
@@ -37,6 +38,6 @@ fun Team.toOverviewDisplayModel(): TeamOverviewDisplayModel {
             darkThemeImageURL = this.darkThemeImageURL,
         ),
         isFavorite = this.isFavorite,
-        regionName = this.regionName,
+        region = this.region.toDisplayModel(),
     )
 }

--- a/core/models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/Team.kt
+++ b/core/models/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/models/Team.kt
@@ -11,5 +11,6 @@ data class Team(
     val darkThemeImageURL: String? = lightThemeImageURL,
     val isFavorite: Boolean = false,
     val isActive: Boolean = false,
-    val regionName: String = "",
+    // We either should rename the EventRegion class, or consider a separate enum for `TeamRegion`.
+    val region: EventRegion = EventRegion.Unknown,
 )

--- a/data/local-sqldelight/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/local/sqldelight/mappers/LocalTeamMappers.kt
+++ b/data/local-sqldelight/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/local/sqldelight/mappers/LocalTeamMappers.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.data.local.sqldelight.mappers
 
+import com.adammcneilly.pocketleague.core.models.EventRegion
 import com.adammcneilly.pocketleague.core.models.Team
 import com.adammcneilly.pocketleague.sqldelight.LocalTeam
 
@@ -11,7 +12,7 @@ fun Team.toLocalTeam(): LocalTeam {
         darkImageURL = this.darkThemeImageURL,
         isFavorite = this.isFavorite,
         isActive = this.isActive,
-        region = this.regionName,
+        region = this.region.name,
     )
 }
 
@@ -23,6 +24,6 @@ fun LocalTeam.toTeam(): Team {
         darkThemeImageURL = this.darkImageURL,
         isFavorite = this.isFavorite,
         isActive = this.isActive ?: false,
-        regionName = this.region.orEmpty(),
+        region = EventRegion.valueOf(this.region.orEmpty()),
     )
 }

--- a/data/local-sqldelight/src/commonMain/sqldelight/com/adammcneilly/pocketleague/sqldelight/LocalTeam.sq
+++ b/data/local-sqldelight/src/commonMain/sqldelight/com/adammcneilly/pocketleague/sqldelight/LocalTeam.sq
@@ -25,6 +25,11 @@ FROM localTeam
 WHERE isFavorite = 1
 ORDER BY name;
 
+selectById:
+SELECT *
+FROM localTeam
+WHERE id = :teamId;
+
 insertFullTeamObject:
 INSERT INTO localTeam(
     id,

--- a/data/octanegg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/octanegg/models/OctaneGGTeamOverview.kt
+++ b/data/octanegg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/octanegg/models/OctaneGGTeamOverview.kt
@@ -29,7 +29,8 @@ data class OctaneGGTeamOverview(
 fun OctaneGGTeamOverview?.toTeam(): Team {
     return Team(
         id = this?.id.orEmpty(),
-        name = this?.name ?: "TBD",
+        name = this?.name ?: "TBD", // This is sus??
         lightThemeImageURL = this?.image,
+        regionName = this?.region.orEmpty(),
     )
 }

--- a/data/octanegg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/octanegg/models/OctaneGGTeamOverview.kt
+++ b/data/octanegg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/octanegg/models/OctaneGGTeamOverview.kt
@@ -31,6 +31,6 @@ fun OctaneGGTeamOverview?.toTeam(): Team {
         id = this?.id.orEmpty(),
         name = this?.name ?: "TBD", // This is sus??
         lightThemeImageURL = this?.image,
-        regionName = this?.region.orEmpty(),
+        region = this?.region.toEventRegion(),
     )
 }

--- a/data/team-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/test/FakeTeamRepository.kt
+++ b/data/team-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/test/FakeTeamRepository.kt
@@ -54,4 +54,8 @@ class FakeTeamRepository : TeamRepository {
     override suspend fun updateIsFavorite(teamId: String, isFavorite: Boolean) {
         _updatedFavorites[teamId] = isFavorite
     }
+
+    override fun getTeamById(teamId: String): Flow<Team> {
+        TODO("Not yet implemented")
+    }
 }

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OctaneGGTeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OctaneGGTeamRepository.kt
@@ -3,6 +3,7 @@ package com.adammcneilly.pocketleague.data.team
 import com.adammcneilly.pocketleague.core.models.Team
 import com.adammcneilly.pocketleague.data.octanegg.models.OctaneGGTeamDetail
 import com.adammcneilly.pocketleague.data.octanegg.models.OctaneGGTeamListResponse
+import com.adammcneilly.pocketleague.data.octanegg.models.OctaneGGTeamOverview
 import com.adammcneilly.pocketleague.data.octanegg.models.toTeam
 import com.adammcneilly.pocketleague.data.remote.BaseKTORClient
 import kotlinx.coroutines.flow.Flow
@@ -18,6 +19,24 @@ class OctaneGGTeamRepository(
 ) : TeamRepository {
     override fun getFavoriteTeams(): Flow<List<Team>> {
         throw UnsupportedOperationException("Fetching favorite teams is not supported by the octane.gg API.")
+    }
+
+    override fun getTeamById(teamId: String): Flow<Team> {
+        return flow {
+            val apiResponse = apiClient.getResponse<OctaneGGTeamOverview>(
+                endpoint = "$TEAMS_ENDPOINT/$teamId",
+            ).map { octaneGGTeamOverview ->
+                octaneGGTeamOverview.toTeam()
+            }
+
+            // If an error occurs, we should log that.
+
+            val team = apiResponse.getOrNull()
+
+            if (team != null) {
+                emit(team)
+            }
+        }
     }
 
     override fun getActiveRLCSTeams(): Flow<List<Team>> {
@@ -54,6 +73,7 @@ class OctaneGGTeamRepository(
     }
 
     companion object {
+        const val TEAMS_ENDPOINT = "/teams"
         const val ACTIVE_TEAMS_ENDPOINT = "/teams/active"
     }
 }

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OfflineFirstTeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/OfflineFirstTeamRepository.kt
@@ -30,6 +30,18 @@ class OfflineFirstTeamRepository(
             }
     }
 
+    override fun getTeamById(teamId: String): Flow<Team> {
+        return localDataSource
+            .getTeamById(teamId)
+            .onStart {
+                remoteDataSource
+                    .getTeamById(teamId)
+                    .collect { team ->
+                        localDataSource.insertTeams(listOf(team))
+                    }
+            }
+    }
+
     override suspend fun insertTeams(teams: List<Team>) {
         localDataSource.insertTeams(teams)
     }

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/SQLDelightTeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/SQLDelightTeamRepository.kt
@@ -5,6 +5,7 @@ import com.adammcneilly.pocketleague.data.local.sqldelight.PocketLeagueDB
 import com.adammcneilly.pocketleague.data.local.sqldelight.mappers.toLocalTeam
 import com.adammcneilly.pocketleague.data.local.sqldelight.mappers.toTeam
 import com.adammcneilly.pocketleague.data.local.sqldelight.util.asFlowList
+import com.adammcneilly.pocketleague.data.local.sqldelight.util.asFlowSingle
 import com.adammcneilly.pocketleague.sqldelight.LocalTeam
 import kotlinx.coroutines.flow.Flow
 
@@ -28,6 +29,13 @@ class SQLDelightTeamRepository(
             .localTeamQueries
             .selectActive()
             .asFlowList(LocalTeam::toTeam)
+    }
+
+    override fun getTeamById(teamId: String): Flow<Team> {
+        return database
+            .localTeamQueries
+            .selectById(teamId)
+            .asFlowSingle(LocalTeam::toTeam)
     }
 
     override suspend fun insertTeams(teams: List<Team>) {

--- a/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/TeamRepository.kt
+++ b/data/team/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/team/TeamRepository.kt
@@ -31,4 +31,11 @@ interface TeamRepository {
         teamId: String,
         isFavorite: Boolean,
     )
+
+    /**
+     * Requests a [Team] entity with the given [teamId].
+     */
+    fun getTeamById(
+        teamId: String,
+    ): Flow<Team>
 }

--- a/feature/teamdetail/build.gradle.kts
+++ b/feature/teamdetail/build.gradle.kts
@@ -13,6 +13,8 @@ kotlin {
                 implementation(project(":core:feature"))
                 implementation(project(":core:models"))
                 implementation(project(":data:team"))
+                implementation(project(":shared:design-system"))
+                implementation(project(":shared:ui"))
                 implementation(compose.foundation)
                 implementation(compose.material3)
                 implementation(compose.materialIconsExtended)

--- a/feature/teamdetail/build.gradle.kts
+++ b/feature/teamdetail/build.gradle.kts
@@ -11,6 +11,8 @@ kotlin {
             dependencies {
                 implementation(project(":core:displaymodels"))
                 implementation(project(":core:feature"))
+                implementation(project(":core:models"))
+                implementation(project(":data:team"))
                 implementation(compose.foundation)
                 implementation(compose.material3)
                 implementation(compose.materialIconsExtended)

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/RosterCardListItem.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/RosterCardListItem.kt
@@ -1,0 +1,20 @@
+package com.adammcneilly.pocketleague.feature.teamdetail
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.adammcneilly.pocketleague.core.displaymodels.PlayerDisplayModel
+import com.adammcneilly.pocketleague.shared.design.system.theme.PocketLeagueTheme
+
+@Composable
+internal fun RosterCardListItem(
+    player: PlayerDisplayModel,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = player.tag,
+        modifier = modifier
+            .padding(PocketLeagueTheme.sizes.cardPadding),
+    )
+}

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
@@ -64,7 +64,7 @@ private fun TeamHeader(
             )
 
             Text(
-                text = team.regionName,
+                text = team.region.name,
             )
         }
     }

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
@@ -13,7 +13,7 @@ internal fun TeamDetailContent(
     modifier: Modifier = Modifier,
 ) {
     Text(
-        text = "Team Detail Screen",
+        text = "Team Detail Screen, Team: ${state.team.name}",
         modifier = modifier,
     )
 }

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
@@ -1,10 +1,17 @@
 package com.adammcneilly.pocketleague.feature.teamdetail
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.adammcneilly.pocketleague.shared.design.system.theme.PocketLeagueTheme
+import com.adammcneilly.pocketleague.shared.ui.components.ListItemDividerCard
+import com.adammcneilly.pocketleague.shared.ui.utils.screenHorizontalPadding
 
 /**
  * UI content for the team detail screen with the given [state].
@@ -19,11 +26,37 @@ internal fun TeamDetailContent(
         contentPadding = PaddingValues(
             vertical = PocketLeagueTheme.sizes.screenPadding,
         ),
+        verticalArrangement = Arrangement.spacedBy(PocketLeagueTheme.sizes.listItemSpacing),
     ) {
         item {
             TeamHeaderListItem(
                 team = state.team,
             )
+        }
+
+        rosterCardSection(state)
+    }
+}
+
+private fun LazyListScope.rosterCardSection(state: TeamDetailScreen.State) {
+    item {
+        // Unify the headers across each screen
+        Text(
+            text = "Roster",
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier
+                .screenHorizontalPadding(),
+        )
+    }
+
+    item {
+        ListItemDividerCard(
+            items = state.roster,
+            modifier = Modifier
+                .fillMaxWidth()
+                .screenHorizontalPadding(),
+        ) { player ->
+            RosterCardListItem(player)
         }
     }
 }

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
@@ -1,8 +1,20 @@
 package com.adammcneilly.pocketleague.feature.teamdetail
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
+import com.adammcneilly.pocketleague.shared.design.system.theme.PocketLeagueTheme
+import com.adammcneilly.pocketleague.shared.ui.components.CircleTeamLogo
+import com.adammcneilly.pocketleague.shared.ui.utils.screenHorizontalPadding
 
 /**
  * UI content for the team detail screen with the given [state].
@@ -12,8 +24,48 @@ internal fun TeamDetailContent(
     state: TeamDetailScreen.State,
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        text = "Team Detail Screen, Team: ${state.team.name}",
+    LazyColumn(
         modifier = modifier,
-    )
+        contentPadding = PaddingValues(
+            vertical = PocketLeagueTheme.sizes.screenPadding,
+        ),
+    ) {
+        item {
+            TeamHeader(
+                team = state.team,
+                modifier = Modifier
+                    .screenHorizontalPadding(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TeamHeader(
+    team: TeamOverviewDisplayModel,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(PocketLeagueTheme.sizes.listItemSpacing),
+    ) {
+        CircleTeamLogo(
+            displayModel = team,
+            modifier = Modifier
+                .size(48.dp),
+        )
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(PocketLeagueTheme.sizes.textSpacing),
+        ) {
+            Text(
+                text = team.name,
+            )
+
+            Text(
+                text = team.regionName,
+            )
+        }
+    }
 }

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
@@ -43,7 +43,7 @@ private fun LazyListScope.rosterCardSection(state: TeamDetailScreen.State) {
         // Unify the headers across each screen
         Text(
             text = "Roster",
-            style = MaterialTheme.typography.headlineSmall,
+            style = MaterialTheme.typography.titleLarge,
             modifier = Modifier
                 .screenHorizontalPadding(),
         )

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailContent.kt
@@ -1,20 +1,10 @@
 package com.adammcneilly.pocketleague.feature.teamdetail
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
 import com.adammcneilly.pocketleague.shared.design.system.theme.PocketLeagueTheme
-import com.adammcneilly.pocketleague.shared.ui.components.CircleTeamLogo
-import com.adammcneilly.pocketleague.shared.ui.utils.screenHorizontalPadding
 
 /**
  * UI content for the team detail screen with the given [state].
@@ -31,40 +21,8 @@ internal fun TeamDetailContent(
         ),
     ) {
         item {
-            TeamHeader(
+            TeamHeaderListItem(
                 team = state.team,
-                modifier = Modifier
-                    .screenHorizontalPadding(),
-            )
-        }
-    }
-}
-
-@Composable
-private fun TeamHeader(
-    team: TeamOverviewDisplayModel,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(PocketLeagueTheme.sizes.listItemSpacing),
-    ) {
-        CircleTeamLogo(
-            displayModel = team,
-            modifier = Modifier
-                .size(48.dp),
-        )
-
-        Column(
-            verticalArrangement = Arrangement.spacedBy(PocketLeagueTheme.sizes.textSpacing),
-        ) {
-            Text(
-                text = team.name,
-            )
-
-            Text(
-                text = team.region.name,
             )
         }
     }

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailPresenter.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailPresenter.kt
@@ -55,7 +55,7 @@ internal class TeamDetailPresenter(
                 }
                 .launchIn(this)
 
-            // TODO: Fetch roster
+            // Coming soon: fetch roster.
         }
 
         return TeamDetailScreen.State(

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailPresenter.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailPresenter.kt
@@ -1,20 +1,39 @@
 package com.adammcneilly.pocketleague.feature.teamdetail
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
+import com.adammcneilly.pocketleague.core.displaymodels.toOverviewDisplayModel
+import com.adammcneilly.pocketleague.core.models.Team
+import com.adammcneilly.pocketleague.data.team.TeamRepository
 import com.slack.circuit.runtime.presenter.Presenter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 
 internal class TeamDetailPresenter(
     private val teamId: String,
+    private val teamRepository: TeamRepository,
 ) : Presenter<TeamDetailScreen.State> {
 
     @Composable
     override fun present(): TeamDetailScreen.State {
-        val team by remember {
+        var team by remember {
             mutableStateOf(TeamOverviewDisplayModel.placeholder)
+        }
+
+        LaunchedEffect(Unit) {
+            teamRepository
+                .getTeamById(teamId)
+                .map(Team::toOverviewDisplayModel)
+                .onEach { displayModel ->
+                    team = displayModel
+                }
+                .launchIn(this)
         }
 
         return TeamDetailScreen.State(

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailPresenter.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailPresenter.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.adammcneilly.pocketleague.core.displaymodels.PlayerDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.toOverviewDisplayModel
 import com.adammcneilly.pocketleague.core.models.Team
@@ -26,6 +27,25 @@ internal class TeamDetailPresenter(
             mutableStateOf(TeamOverviewDisplayModel.placeholder)
         }
 
+        var roster by remember {
+            mutableStateOf(
+                listOf(
+                    PlayerDisplayModel(
+                        id = "Alpha54",
+                        tag = "AdamMc54",
+                    ),
+                    PlayerDisplayModel(
+                        id = "Radosin",
+                        tag = "Radosin",
+                    ),
+                    PlayerDisplayModel(
+                        id = "Zen",
+                        tag = "PleaZENtlyPlump",
+                    ),
+                ),
+            )
+        }
+
         LaunchedEffect(Unit) {
             teamRepository
                 .getTeamById(teamId)
@@ -34,10 +54,13 @@ internal class TeamDetailPresenter(
                     team = displayModel
                 }
                 .launchIn(this)
+
+            // TODO: Fetch roster
         }
 
         return TeamDetailScreen.State(
             team = team,
+            roster = roster,
         ) { event ->
             // Handle UI events
         }

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailScreen.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.feature.teamdetail
 
+import com.adammcneilly.pocketleague.core.displaymodels.PlayerDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
 import com.adammcneilly.pocketleague.core.feature.CommonParcelize
 import com.adammcneilly.pocketleague.data.team.TeamRepository
@@ -27,6 +28,7 @@ data class TeamDetailScreen(
      */
     data class State(
         val team: TeamOverviewDisplayModel,
+        val roster: List<PlayerDisplayModel>,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
 

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailScreen.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamDetailScreen.kt
@@ -2,6 +2,7 @@ package com.adammcneilly.pocketleague.feature.teamdetail
 
 import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
 import com.adammcneilly.pocketleague.core.feature.CommonParcelize
+import com.adammcneilly.pocketleague.data.team.TeamRepository
 import com.slack.circuit.runtime.CircuitContext
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
@@ -11,6 +12,7 @@ import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 /**
  * Screen component for the team detail feature.
@@ -57,12 +59,14 @@ data class TeamDetailScreen(
      * Factory to create a [TeamDetailPresenter].
      */
     object PresenterFactory : Presenter.Factory, KoinComponent {
+        private val teamRepository: TeamRepository by inject()
 
         override fun create(screen: Screen, navigator: Navigator, context: CircuitContext): Presenter<*>? {
             return when (screen) {
                 is TeamDetailScreen -> {
                     TeamDetailPresenter(
                         teamId = screen.teamId,
+                        teamRepository = teamRepository,
                     )
                 }
 

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamHeaderListItem.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamHeaderListItem.kt
@@ -15,7 +15,7 @@ import com.adammcneilly.pocketleague.shared.ui.components.CircleTeamLogo
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TeamHeaderListItem(
+internal fun TeamHeaderListItem(
     team: TeamOverviewDisplayModel,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamHeaderListItem.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamHeaderListItem.kt
@@ -3,6 +3,7 @@ package com.adammcneilly.pocketleague.feature.teamdetail
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -31,11 +32,13 @@ internal fun TeamHeaderListItem(
         headlineText = {
             Text(
                 text = team.name,
+                style = MaterialTheme.typography.headlineMedium,
             )
         },
         supportingText = {
             Text(
                 text = team.region.name,
+                style = MaterialTheme.typography.titleMedium,
             )
         },
     )

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamHeaderListItem.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/TeamHeaderListItem.kt
@@ -1,0 +1,42 @@
+package com.adammcneilly.pocketleague.feature.teamdetail
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.adammcneilly.pocketleague.core.displaymodels.TeamOverviewDisplayModel
+import com.adammcneilly.pocketleague.shared.ui.components.CircleTeamLogo
+
+/**
+ * Component that renders overview information about a team (logo, name, region)
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TeamHeaderListItem(
+    team: TeamOverviewDisplayModel,
+    modifier: Modifier = Modifier,
+) {
+    ListItem(
+        modifier = modifier,
+        leadingContent = {
+            CircleTeamLogo(
+                displayModel = team,
+                modifier = Modifier
+                    .size(48.dp),
+            )
+        },
+        headlineText = {
+            Text(
+                text = team.name,
+            )
+        },
+        supportingText = {
+            Text(
+                text = team.region.name,
+            )
+        },
+    )
+}

--- a/shared/app/build.gradle.kts
+++ b/shared/app/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
                 implementation(project(":data:match"))
                 implementation(project(":data:octanegg"))
                 implementation(project(":data:remote"))
+                implementation(project(":data:team"))
                 implementation(project(":feature:eventdetail"))
                 implementation(project(":feature:teamdetail"))
                 implementation(project(":shared:design-system"))

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/DateTimeModule.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/DateTimeModule.kt
@@ -1,7 +1,6 @@
 package com.adammcneilly.pocketleague.shared.app.di
 
 import com.adammcneilly.pocketleague.core.datetime.DateTimeFormatter
-import com.adammcneilly.pocketleague.core.datetime.DebugClock
 import com.adammcneilly.pocketleague.core.datetime.dateTimeFormatter
 import kotlinx.datetime.Clock
 import org.koin.dsl.module
@@ -11,7 +10,8 @@ import org.koin.dsl.module
  */
 val dateTimeModule = module {
     single<Clock> {
-        DebugClock()
+        Clock.System
+//        DebugClock()
     }
 
     single<DateTimeFormatter> {

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/RepositoryModule.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/RepositoryModule.kt
@@ -4,6 +4,10 @@ import com.adammcneilly.pocketleague.data.event.EventRepository
 import com.adammcneilly.pocketleague.data.event.OfflineFirstEventRepository
 import com.adammcneilly.pocketleague.data.match.MatchRepository
 import com.adammcneilly.pocketleague.data.match.OfflineFirstMatchRepository
+import com.adammcneilly.pocketleague.data.team.OctaneGGTeamRepository
+import com.adammcneilly.pocketleague.data.team.OfflineFirstTeamRepository
+import com.adammcneilly.pocketleague.data.team.SQLDelightTeamRepository
+import com.adammcneilly.pocketleague.data.team.TeamRepository
 import org.koin.dsl.module
 
 val repositoryModule = module {
@@ -18,6 +22,17 @@ val repositoryModule = module {
         OfflineFirstEventRepository(
             localEventService = get(),
             remoteEventService = get(),
+        )
+    }
+
+    single<TeamRepository> {
+        OfflineFirstTeamRepository(
+            localDataSource = SQLDelightTeamRepository(
+                database = get(),
+            ),
+            remoteDataSource = OctaneGGTeamRepository(
+                apiClient = get(),
+            ),
         )
     }
 }

--- a/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameListItem.kt
+++ b/shared/ui/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/ui/game/GameListItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.adammcneilly.pocketleague.core.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.GameTeamResultDisplayModel
+import com.adammcneilly.pocketleague.shared.design.system.theme.PocketLeagueTheme
 import com.adammcneilly.pocketleague.shared.ui.placeholder.PlaceholderDefaults
 import com.adammcneilly.pocketleague.shared.ui.placeholder.placeholderMaterial
 
@@ -44,7 +45,7 @@ fun GameListItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(16.dp)
+            .padding(PocketLeagueTheme.sizes.cardPadding)
             .placeholderMaterial(
                 visible = displayModel.isPlaceholder,
                 color = PlaceholderDefaults.cardColor(),


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Adds a header list item, and card with current roster (data layer coming soon) to the team detail screen. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

Manual testing. 

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->

<details>

<summary>Team Detail With Stub Roster</summary>
    
![Team Detail](https://github.com/AdamMc331/PocketLeague/assets/9515997/f7662bba-8009-4344-a386-44b9b0ded962)


</details>