### PR TITLE
Adding country flag emoji support on roster card.

### DIFF
--- a/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestDisplayModel.kt
+++ b/core/displaymodels-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/test/TestDisplayModel.kt
@@ -28,18 +28,21 @@ object TestDisplayModel {
         id = "cheeseId",
         tag = "CHEESE",
         role = null,
+        countryFlagEmojiUnicode = "\uD83C\uDDFA\uD83C\uDDF8",
     )
 
     val sosa = PlayerDisplayModel(
         id = "sosaId",
         tag = "sosa",
         role = null,
+        countryFlagEmojiUnicode = "\uD83C\uDDE8\uD83C\uDDE6",
     )
 
     val zps = PlayerDisplayModel(
         id = "zpsId",
         tag = "ZPS",
         role = null,
+        countryFlagEmojiUnicode = "\uD83C\uDDFA\uD83C\uDDF8",
     )
 
     val knights = TeamOverviewDisplayModel(

--- a/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/PlayerDisplayModel.kt
+++ b/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/PlayerDisplayModel.kt
@@ -11,7 +11,7 @@ data class PlayerDisplayModel(
     val id: String,
     val tag: String,
     val role: String?,
-    val countryFlagUnicode: String,
+    val countryFlagEmojiUnicode: String,
 )
 
 /**
@@ -31,6 +31,6 @@ fun Player.toDisplayModel(
         id = this.id,
         tag = this.tag,
         role = role,
-        countryFlagUnicode = localeHelper.getFlagEmoji(countryCode),
+        countryFlagEmojiUnicode = localeHelper.getFlagEmoji(countryCode),
     )
 }

--- a/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/PlayerDisplayModel.kt
+++ b/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/PlayerDisplayModel.kt
@@ -1,5 +1,7 @@
 package com.adammcneilly.pocketleague.core.displaymodels
 
+import com.adammcneilly.pocketleague.core.locale.LocaleHelper
+import com.adammcneilly.pocketleague.core.locale.provideLocaleHelper
 import com.adammcneilly.pocketleague.core.models.Player
 
 /**
@@ -9,12 +11,15 @@ data class PlayerDisplayModel(
     val id: String,
     val tag: String,
     val role: String?,
+    val countryFlagUnicode: String,
 )
 
 /**
  * Converts a [Player] to its corresponding [PlayerDisplayModel]
  */
-fun Player.toDisplayModel(): PlayerDisplayModel {
+fun Player.toDisplayModel(
+    localeHelper: LocaleHelper = provideLocaleHelper(),
+): PlayerDisplayModel {
     // Maybe roles can be an enum instead of strings?
     val role = when {
         this.isCoach -> "Coach"
@@ -26,5 +31,6 @@ fun Player.toDisplayModel(): PlayerDisplayModel {
         id = this.id,
         tag = this.tag,
         role = role,
+        countryFlagUnicode = localeHelper.getFlagEmoji(countryCode),
     )
 }

--- a/core/displaymodels/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/displaymodels/GameTeamResultDisplayModelTest.kt
+++ b/core/displaymodels/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/displaymodels/GameTeamResultDisplayModelTest.kt
@@ -17,6 +17,7 @@ class GameTeamResultDisplayModelTest {
             GamePlayerResult(
                 player = Player(
                     tag = "AdamMc331",
+                    countryCode = "US",
                 ),
                 stats = Stats(
                     core = CoreStats(
@@ -27,6 +28,7 @@ class GameTeamResultDisplayModelTest {
             GamePlayerResult(
                 player = Player(
                     tag = "PleasantlyPlump",
+                    countryCode = "CA",
                 ),
                 stats = Stats(
                     core = CoreStats(
@@ -37,6 +39,7 @@ class GameTeamResultDisplayModelTest {
             GamePlayerResult(
                 player = Player(
                     tag = "mTeo",
+                    countryCode = "US",
                 ),
                 stats = Stats(
                     core = CoreStats(

--- a/core/locale/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.kt
+++ b/core/locale/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.kt
@@ -16,10 +16,19 @@ interface LocaleHelper {
      * of that country's flag emoji.
      */
     fun getFlagEmoji(countryCode: String): String
+}
 
-    companion object {
-        const val UNICODE_CHAR_OFFSET_START = 127397
-    }
+/**
+ * To understand where this number came from, read this post: https://dev.to/jorik/country-code-to-flag-emoji-a21
+ *
+ * TL;DR -> Unicode codepoint for 'A' - UTF-16 value for 'A'.
+ * We can add UTF-16 value for any char to this constant, and get the unicode
+ * codepoint for that char.
+ */
+fun Char.toCodePoint(): Int {
+    val unicodeOffsetStart = 127397
+
+    return this.code + unicodeOffsetStart
 }
 
 /**

--- a/core/locale/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.kt
+++ b/core/locale/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.kt
@@ -10,6 +10,16 @@ interface LocaleHelper {
      * "us" should return "United States".
      */
     fun getCountryDisplayName(countryCode: String): String
+
+    /**
+     * Given a [countryCode], convert that information to the unicode value
+     * of that country's flag emoji.
+     */
+    fun getFlagEmoji(countryCode: String): String
+
+    companion object {
+        const val UNICODE_CHAR_OFFSET_START = 127397
+    }
 }
 
 /**

--- a/core/locale/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.kt
+++ b/core/locale/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.kt
@@ -25,6 +25,7 @@ interface LocaleHelper {
  * We can add UTF-16 value for any char to this constant, and get the unicode
  * codepoint for that char.
  */
+@Suppress("MagicNumber")
 fun Char.toCodePoint(): Int {
     val unicodeOffsetStart = 127397
 

--- a/core/locale/src/iosMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.ios.kt
+++ b/core/locale/src/iosMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.ios.kt
@@ -11,6 +11,19 @@ class IOSLocaleHelper : LocaleHelper {
     override fun getCountryDisplayName(countryCode: String): String {
         return NSLocale.currentLocale().localizedStringForCountryCode(countryCode).orEmpty()
     }
+
+    override fun getFlagEmoji(countryCode: String): String {
+        // Not sure how to get this to work, what's below is from SO on converting in Obj-C.
+        return ""
+        //    wchar_t bytes[2] = {
+        //        base +[countryCode characterAtIndex:0],
+        //        base +[countryCode characterAtIndex:1]
+        //    };
+        //
+        //    return [[NSString alloc] initWithBytes:bytes
+        //                                    length:countryCode.length *sizeof(wchar_t)
+        //                                  encoding:NSUTF32LittleEndianStringEncoding];
+    }
 }
 
 /**

--- a/core/locale/src/jvmMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.jvm.kt
+++ b/core/locale/src/jvmMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.jvm.kt
@@ -12,6 +12,10 @@ class JVMLocaleHelper : LocaleHelper {
     }
 
     override fun getFlagEmoji(countryCode: String): String {
+        if (countryCode.length != 2) {
+            throw IllegalArgumentException("Country code \"$countryCode\" invalid, expected two characters.")
+        }
+
         val codePoints = countryCode
             .uppercase()
             .map(Char::toCodePoint)

--- a/core/locale/src/jvmMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.jvm.kt
+++ b/core/locale/src/jvmMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.jvm.kt
@@ -14,9 +14,7 @@ class JVMLocaleHelper : LocaleHelper {
     override fun getFlagEmoji(countryCode: String): String {
         val codePoints = countryCode
             .uppercase()
-            .map { char ->
-                char.code + LocaleHelper.UNICODE_CHAR_OFFSET_START
-            }
+            .map(Char::toCodePoint)
             .toIntArray()
 
         return String(codePoints, 0, 2)

--- a/core/locale/src/jvmMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.jvm.kt
+++ b/core/locale/src/jvmMain/kotlin/com/adammcneilly/pocketleague/core/locale/LocaleHelper.jvm.kt
@@ -10,6 +10,17 @@ class JVMLocaleHelper : LocaleHelper {
     override fun getCountryDisplayName(countryCode: String): String {
         return Locale("", countryCode).getDisplayName(Locale.getDefault())
     }
+
+    override fun getFlagEmoji(countryCode: String): String {
+        val codePoints = countryCode
+            .uppercase()
+            .map { char ->
+                char.code + LocaleHelper.UNICODE_CHAR_OFFSET_START
+            }
+            .toIntArray()
+
+        return String(codePoints, 0, 2)
+    }
 }
 
 /**

--- a/feature/teamdetail/build.gradle.kts
+++ b/feature/teamdetail/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
             dependencies {
                 implementation(project(":core:displaymodels"))
                 implementation(project(":core:feature"))
+                implementation(project(":core:locale"))
                 implementation(project(":core:models"))
                 implementation(project(":data:player"))
                 implementation(project(":data:team"))

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/RosterCardListItem.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/RosterCardListItem.kt
@@ -27,7 +27,7 @@ internal fun RosterCardListItem(
         ),
         headlineText = {
             Text(
-                text = playerText,
+                text = "${player.countryFlagUnicode} $playerText",
             )
         },
     )

--- a/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/RosterCardListItem.kt
+++ b/feature/teamdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/teamdetail/RosterCardListItem.kt
@@ -27,7 +27,7 @@ internal fun RosterCardListItem(
         ),
         headlineText = {
             Text(
-                text = "${player.countryFlagUnicode} $playerText",
+                text = "${player.countryFlagEmojiUnicode} $playerText",
             )
         },
     )


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Roster card now shows the emoji of the player's country in front of their name. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

Manual testing. 

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->

<details>

<summary>Team Detail</summary>
    
![ComplexityRoster](https://github.com/AdamMc331/PocketLeague/assets/9515997/f52d98d4-5cbe-44f5-b55b-bea90877eede)


</details>