### PR TITLE
Adding TimeProvider interface.

### DIFF
--- a/android/widgets/src/main/java/com/adammcneilly/pocketleague/widgets/UpcomingMatchesWidget.kt
+++ b/android/widgets/src/main/java/com/adammcneilly/pocketleague/widgets/UpcomingMatchesWidget.kt
@@ -34,13 +34,13 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
+import com.adammcneilly.pocketleague.core.datetime.SystemTimeProvider
 import com.adammcneilly.pocketleague.core.displaymodels.MatchDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.toDetailDisplayModel
 import com.adammcneilly.pocketleague.data.local.sqldelight.DatabaseDriverFactory
 import com.adammcneilly.pocketleague.data.local.sqldelight.PocketLeagueDB
 import com.adammcneilly.pocketleague.data.local.sqldelight.mappers.toMatch
 import com.adammcneilly.pocketleague.sqldelight.MatchWithEventAndTeams
-import kotlinx.datetime.Clock
 import java.util.concurrent.TimeUnit
 
 /**
@@ -61,7 +61,7 @@ class UpcomingMatchesWidget : GlanceAppWidget() {
             .executeAsList()
             .map(MatchWithEventAndTeams::toMatch)
             .map { match ->
-                match.toDetailDisplayModel(Clock.System)
+                match.toDetailDisplayModel(SystemTimeProvider)
             }
 
         println("ARM - Rendering matches: ${matchesToShow.size}")

--- a/android/widgets/src/main/java/com/adammcneilly/pocketleague/widgets/UpcomingMatchesWidgetWorker.kt
+++ b/android/widgets/src/main/java/com/adammcneilly/pocketleague/widgets/UpcomingMatchesWidgetWorker.kt
@@ -5,6 +5,7 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.WorkerParameters
+import com.adammcneilly.pocketleague.core.datetime.SystemTimeProvider
 import com.adammcneilly.pocketleague.data.local.sqldelight.DatabaseDriverFactory
 import com.adammcneilly.pocketleague.data.local.sqldelight.PocketLeagueDB
 import com.adammcneilly.pocketleague.data.match.MatchRepository
@@ -12,7 +13,6 @@ import com.adammcneilly.pocketleague.data.match.OctaneGGMatchService
 import com.adammcneilly.pocketleague.data.match.OfflineFirstMatchRepository
 import com.adammcneilly.pocketleague.data.match.SQLDelightMatchService
 import com.adammcneilly.pocketleague.data.octanegg.OctaneGGAPIClient
-import kotlinx.datetime.Clock
 
 /**
  * An implementation of [CoroutineWorker] to request and persist upcoming matches.
@@ -34,7 +34,7 @@ class UpcomingMatchesWidgetWorker(
             localDataSource = SQLDelightMatchService(PocketLeagueDB(DatabaseDriverFactory(appContext).createDriver())),
             remoteDataSource = OctaneGGMatchService(
                 apiClient = OctaneGGAPIClient,
-                timeProvider = Clock.System,
+                timeProvider = SystemTimeProvider,
             ),
         )
     }

--- a/android/widgets/src/main/java/com/adammcneilly/pocketleague/widgets/UpcomingMatchesWidgetWorker.kt
+++ b/android/widgets/src/main/java/com/adammcneilly/pocketleague/widgets/UpcomingMatchesWidgetWorker.kt
@@ -34,7 +34,7 @@ class UpcomingMatchesWidgetWorker(
             localDataSource = SQLDelightMatchService(PocketLeagueDB(DatabaseDriverFactory(appContext).createDriver())),
             remoteDataSource = OctaneGGMatchService(
                 apiClient = OctaneGGAPIClient,
-                clock = Clock.System,
+                timeProvider = Clock.System,
             ),
         )
     }

--- a/core/datetime-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/test/FakeDateTimeFormatter.kt
+++ b/core/datetime-test/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/test/FakeDateTimeFormatter.kt
@@ -1,7 +1,7 @@
 package com.adammcneilly.pocketleague.core.datetime.test
 
 import com.adammcneilly.pocketleague.core.datetime.DateTimeFormatter
-import kotlinx.datetime.TimeZone
+import com.adammcneilly.pocketleague.core.datetime.TimeZone
 
 class FakeDateTimeFormatter : DateTimeFormatter {
 

--- a/core/datetime/build.gradle.kts
+++ b/core/datetime/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(libs.kotlinx.datetime)
+                implementation(libs.kotlinx.datetime)
 
                 implementation(kotlin("stdlib"))
             }

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatter.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatter.kt
@@ -1,9 +1,8 @@
 package com.adammcneilly.pocketleague.core.datetime
 
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 
 /**
  * Creates an implementation of [DateTimeFormatter] for a specific platform.
@@ -47,11 +46,9 @@ interface DateTimeFormatter {
      */
     fun isBeforeNow(
         utcString: String,
-        clock: Clock,
+        timeProvider: TimeProvider,
     ): Boolean {
-        val instant = Instant.parse(utcString)
-
-        return instant < clock.now()
+        return utcString < timeProvider.now()
     }
 
     /**
@@ -62,15 +59,15 @@ interface DateTimeFormatter {
      */
     fun getRelativeTimestamp(
         utcString: String,
-        clock: Clock,
+        timeProvider: TimeProvider,
     ): String? {
-        if (!isBeforeNow(utcString, clock)) {
+        if (!isBeforeNow(utcString, timeProvider)) {
             return null
         }
 
         val instant = Instant.parse(utcString)
 
-        val now = clock.now()
+        val now = timeProvider.now().toInstant()
 
         val duration = now.minus(instant)
 

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugTimeProvider.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugTimeProvider.kt
@@ -1,18 +1,17 @@
 package com.adammcneilly.pocketleague.core.datetime
 
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 /**
  * Custom implementation of a [Clock] to hardcode a specific date.
  *
  * Allows us to test the app at any given point in time.
  */
-class DebugClock(
+class DebugTimeProvider(
     private val dateString: String = "2023-03-02T16:00:00Z",
-) : Clock {
+) : TimeProvider {
 
-    override fun now(): Instant {
-        return Instant.parse(dateString)
+    override fun now(): String {
+        return dateString
     }
 }

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugTimeProvider.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/DebugTimeProvider.kt
@@ -1,9 +1,7 @@
 package com.adammcneilly.pocketleague.core.datetime
 
-import kotlinx.datetime.Clock
-
 /**
- * Custom implementation of a [Clock] to hardcode a specific date.
+ * Custom implementation of a [TimeProvider] to hardcode a specific date.
  *
  * Allows us to test the app at any given point in time.
  */

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/SystemTimeProvider.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/SystemTimeProvider.kt
@@ -1,0 +1,13 @@
+package com.adammcneilly.pocketleague.core.datetime
+
+import kotlinx.datetime.Clock
+
+/**
+ * Implementation of [TimeProvider] to provide the current time from the platform's system.
+ */
+object SystemTimeProvider : TimeProvider {
+
+    override fun now(): String {
+        return Clock.System.now().toString()
+    }
+}

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeProvider.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeProvider.kt
@@ -1,5 +1,8 @@
 package com.adammcneilly.pocketleague.core.datetime
 
+import kotlinx.datetime.toInstant
+import kotlin.time.Duration.Companion.days
+
 /**
  * Similar to a kotlinx Clock instance, this time provider allows a platform
  * to specify [now], without any dependencies on a particular datetime library.
@@ -9,4 +12,11 @@ interface TimeProvider {
      * Return a string representation (in ISO format) of the current time.
      */
     fun now(): String
+
+    /**
+     * Return a string representation of [now] minus [numDays].
+     */
+    fun daysAgo(numDays: Int): String {
+        return now().toInstant().minus(numDays.days).toString()
+    }
 }

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeProvider.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeProvider.kt
@@ -1,0 +1,12 @@
+package com.adammcneilly.pocketleague.core.datetime
+
+/**
+ * Similar to a kotlinx Clock instance, this time provider allows a platform
+ * to specify [now], without any dependencies on a particular datetime library.
+ */
+interface TimeProvider {
+    /**
+     * Return a string representation (in ISO format) of the current time.
+     */
+    fun now(): String
+}

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeProvider.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeProvider.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.core.datetime
 
+import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
 import kotlin.time.Duration.Companion.days
 
@@ -18,5 +19,12 @@ interface TimeProvider {
      */
     fun daysAgo(numDays: Int): String {
         return now().toInstant().minus(numDays.days).toString()
+    }
+
+    /**
+     * Given [epochSeconds], convert it to an ISO format string.
+     */
+    fun fromEpochSeconds(epochSeconds: Long): String {
+        return Instant.fromEpochSeconds(epochSeconds).toString()
     }
 }

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeZone.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeZone.kt
@@ -10,7 +10,6 @@ typealias KotlinTimeZone = kotlinx.datetime.TimeZone
 enum class TimeZone {
     UTC,
     SYSTEM_DEFAULT,
-    
     ;
 
     fun toKotlinTimeZone(): KotlinTimeZone {

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeZone.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeZone.kt
@@ -12,6 +12,10 @@ enum class TimeZone {
     SYSTEM_DEFAULT,
     ;
 
+    /**
+     * Converts our own [TimeZone] instance to a [KotlinTimeZone] for some
+     * date management.
+     */
     fun toKotlinTimeZone(): KotlinTimeZone {
         return when (this) {
             UTC -> KotlinTimeZone.UTC

--- a/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeZone.kt
+++ b/core/datetime/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/datetime/TimeZone.kt
@@ -1,0 +1,22 @@
+package com.adammcneilly.pocketleague.core.datetime
+
+typealias KotlinTimeZone = kotlinx.datetime.TimeZone
+
+/**
+ * An enumeration of possible timezones used in the application.
+ *
+ * Ideally, we either want [SYSTEM_DEFAULT], but potentially [UTC].
+ */
+enum class TimeZone {
+    UTC,
+    SYSTEM_DEFAULT,
+    
+    ;
+
+    fun toKotlinTimeZone(): KotlinTimeZone {
+        return when (this) {
+            UTC -> KotlinTimeZone.UTC
+            SYSTEM_DEFAULT -> KotlinTimeZone.currentSystemDefault()
+        }
+    }
+}

--- a/core/datetime/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatterTest.kt
+++ b/core/datetime/src/commonTest/kotlin/com/adammcneilly/pocketleague/core/datetime/DateTimeFormatterTest.kt
@@ -14,9 +14,9 @@ class DateTimeFormatterTest {
         val pastDate = "2023-07-18T12:00:00Z"
         val now = "2024-07-18T12:00:00Z"
 
-        val clock = DebugClock(now)
+        val timeProvider = DebugTimeProvider(now)
 
-        assertTrue(dateTimeFormatter.isBeforeNow(pastDate, clock))
+        assertTrue(dateTimeFormatter.isBeforeNow(pastDate, timeProvider))
     }
 
     @Test
@@ -24,18 +24,18 @@ class DateTimeFormatterTest {
         val futureDate = "2023-07-18T12:00:00Z"
         val now = "2022-07-18T12:00:00Z"
 
-        val clock = DebugClock(now)
+        val timeProvider = DebugTimeProvider(now)
 
-        assertFalse(dateTimeFormatter.isBeforeNow(futureDate, clock))
+        assertFalse(dateTimeFormatter.isBeforeNow(futureDate, timeProvider))
     }
 
     @Test
     fun `isBeforeNow returns false for same date`() {
         val now = "2022-07-18T12:00:00Z"
 
-        val clock = DebugClock(now)
+        val timeProvider = DebugTimeProvider(now)
 
-        assertFalse(dateTimeFormatter.isBeforeNow(now, clock))
+        assertFalse(dateTimeFormatter.isBeforeNow(now, timeProvider))
     }
 
     @Test
@@ -43,9 +43,9 @@ class DateTimeFormatterTest {
         val pastDate = "2023-07-18T11:55:00Z"
         val now = "2023-07-18T12:00:00Z"
 
-        val clock = DebugClock(now)
+        val timeProvider = DebugTimeProvider(now)
 
-        assertThat("5m ago").isEqualTo(dateTimeFormatter.getRelativeTimestamp(pastDate, clock))
+        assertThat("5m ago").isEqualTo(dateTimeFormatter.getRelativeTimestamp(pastDate, timeProvider))
     }
 
     @Test
@@ -53,9 +53,9 @@ class DateTimeFormatterTest {
         val pastDate = "2023-07-18T05:55:00Z"
         val now = "2023-07-18T12:00:00Z"
 
-        val clock = DebugClock(now)
+        val timeProvider = DebugTimeProvider(now)
 
-        assertThat("6h ago").isEqualTo(dateTimeFormatter.getRelativeTimestamp(pastDate, clock))
+        assertThat("6h ago").isEqualTo(dateTimeFormatter.getRelativeTimestamp(pastDate, timeProvider))
     }
 
     @Test
@@ -63,9 +63,9 @@ class DateTimeFormatterTest {
         val pastDate = "2023-07-12T11:55:00Z"
         val now = "2023-07-18T12:00:00Z"
 
-        val clock = DebugClock(now)
+        val timeProvider = DebugTimeProvider(now)
 
-        assertThat("6d ago").isEqualTo(dateTimeFormatter.getRelativeTimestamp(pastDate, clock))
+        assertThat("6d ago").isEqualTo(dateTimeFormatter.getRelativeTimestamp(pastDate, timeProvider))
     }
 
     @Test
@@ -73,9 +73,9 @@ class DateTimeFormatterTest {
         val pastDate = "2022-07-18T11:55:00Z"
         val now = "2023-07-18T12:00:00Z"
 
-        val clock = DebugClock(now)
+        val timeProvider = DebugTimeProvider(now)
 
-        assertThat("365d ago").isEqualTo(dateTimeFormatter.getRelativeTimestamp(pastDate, clock))
+        assertThat("365d ago").isEqualTo(dateTimeFormatter.getRelativeTimestamp(pastDate, timeProvider))
     }
 
     @Test
@@ -83,8 +83,8 @@ class DateTimeFormatterTest {
         val futureDate = "2024-07-18T11:55:00Z"
         val now = "2023-07-18T12:00:00Z"
 
-        val clock = DebugClock(now)
+        val timeProvider = DebugTimeProvider(now)
 
-        assertThat(dateTimeFormatter.getRelativeTimestamp(futureDate, clock)).isNull()
+        assertThat(dateTimeFormatter.getRelativeTimestamp(futureDate, timeProvider)).isNull()
     }
 }

--- a/core/datetime/src/iosMain/kotlin/com/adammcneilly/pocketleague/core/datetime/IOSDateTimeFormatter.kt
+++ b/core/datetime/src/iosMain/kotlin/com/adammcneilly/pocketleague/core/datetime/IOSDateTimeFormatter.kt
@@ -1,17 +1,19 @@
 package com.adammcneilly.pocketleague.core.datetime
 
 import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toNSDate
 import platform.Foundation.NSDateFormatter
 
 /**
- * Coming soon!
+ * Formats dates for the iOS platform.
  */
 class IOSDateTimeFormatter : DateTimeFormatter {
 
     /**
      * Inspiration: https://github.com/Kotlin/kotlinx-datetime/issues/211#issuecomment-1285745207
+     *
+     * NOTE: This function does nothing with timeZone, it might not work
+     * right on iOS?
      */
     override fun formatUTCString(
         utcString: String,

--- a/core/datetime/src/jvmMain/kotlin/com/adammcneilly/pocketleague/core/datetime/JVMDateTimeFormatter.kt
+++ b/core/datetime/src/jvmMain/kotlin/com/adammcneilly/pocketleague/core/datetime/JVMDateTimeFormatter.kt
@@ -1,7 +1,6 @@
 package com.adammcneilly.pocketleague.core.datetime
 
 import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toLocalDateTime
 import java.time.format.DateTimeFormatter
@@ -21,7 +20,7 @@ class JVMDateTimeFormatter : com.adammcneilly.pocketleague.core.datetime.DateTim
     ): String? {
         val instant = Instant.parse(utcString)
 
-        val localDateTime = instant.toLocalDateTime(timeZone)
+        val localDateTime = instant.toLocalDateTime(timeZone.toKotlinTimeZone())
 
         val dateTimeFormatter = DateTimeFormatter.ofPattern(formatPattern)
 

--- a/core/datetime/src/jvmTest/kotlin/com/adammcneilly/pocketleague/core/datetime/JVMDateTimeFormatterTest.kt
+++ b/core/datetime/src/jvmTest/kotlin/com/adammcneilly/pocketleague/core/datetime/JVMDateTimeFormatterTest.kt
@@ -1,6 +1,5 @@
 package com.adammcneilly.pocketleague.core.datetime
 
-import kotlinx.datetime.TimeZone
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventDetailDisplayModel.kt
+++ b/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventDetailDisplayModel.kt
@@ -1,11 +1,11 @@
 package com.adammcneilly.pocketleague.core.displaymodels
 
+import com.adammcneilly.pocketleague.core.datetime.TimeZone
 import com.adammcneilly.pocketleague.core.datetime.dateTimeFormatter
 import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.EventRegion
 import com.adammcneilly.pocketleague.core.models.EventStage
 import com.adammcneilly.pocketleague.core.models.EventTier
-import kotlinx.datetime.TimeZone
 
 private const val EVENT_DATE_FORMAT = "MMM dd, yyyy"
 
@@ -60,14 +60,14 @@ fun Event.toDetailDisplayModel(): EventDetailDisplayModel {
             dateTimeFormatter.formatUTCString(
                 utcString = startDate,
                 formatPattern = EVENT_DATE_FORMAT,
-                timeZone = TimeZone.currentSystemDefault(),
+                timeZone = TimeZone.SYSTEM_DEFAULT,
             )
         }.orEmpty(),
         endDate = this.endDateUTC?.let { endDate ->
             dateTimeFormatter.formatUTCString(
                 utcString = endDate,
                 formatPattern = EVENT_DATE_FORMAT,
-                timeZone = TimeZone.currentSystemDefault(),
+                timeZone = TimeZone.SYSTEM_DEFAULT,
             )
         }.orEmpty(),
         name = this.name,

--- a/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventStageSummaryDisplayModel.kt
+++ b/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventStageSummaryDisplayModel.kt
@@ -1,8 +1,8 @@
 package com.adammcneilly.pocketleague.core.displaymodels
 
+import com.adammcneilly.pocketleague.core.datetime.TimeZone
 import com.adammcneilly.pocketleague.core.datetime.dateTimeFormatter
 import com.adammcneilly.pocketleague.core.models.EventStage
-import kotlinx.datetime.TimeZone
 
 private const val STAGE_DATE_FORMAT = "MMM dd, yyyy"
 
@@ -52,14 +52,14 @@ fun EventStage.toSummaryDisplayModel(): EventStageSummaryDisplayModel {
             dateTimeFormatter.formatUTCString(
                 utcString = startDate,
                 formatPattern = STAGE_DATE_FORMAT,
-                timeZone = TimeZone.currentSystemDefault(),
+                timeZone = TimeZone.SYSTEM_DEFAULT,
             )
         }.orEmpty(),
         endDate = this.endDateUTC?.let { endDate ->
             dateTimeFormatter.formatUTCString(
                 utcString = endDate,
                 formatPattern = STAGE_DATE_FORMAT,
-                timeZone = TimeZone.currentSystemDefault(),
+                timeZone = TimeZone.SYSTEM_DEFAULT,
             )
         }.orEmpty(),
         stageId = this.id,

--- a/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventSummaryDisplayModel.kt
+++ b/core/displaymodels/src/commonMain/kotlin/com/adammcneilly/pocketleague/core/displaymodels/EventSummaryDisplayModel.kt
@@ -1,10 +1,10 @@
 package com.adammcneilly.pocketleague.core.displaymodels
 
 import com.adammcneilly.pocketleague.core.datetime.DateTimeFormatter
+import com.adammcneilly.pocketleague.core.datetime.TimeZone
 import com.adammcneilly.pocketleague.core.datetime.dateTimeFormatter
 import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.EventStage
-import kotlinx.datetime.TimeZone
 
 private const val EVENT_DATE_FORMAT = "MMM dd, yyyy"
 
@@ -83,7 +83,7 @@ fun Event.toSummaryDisplayModel(
         dateTimeFormatter.formatUTCString(
             utcString = startDate,
             formatPattern = EVENT_DATE_FORMAT,
-            timeZone = TimeZone.currentSystemDefault(),
+            timeZone = TimeZone.SYSTEM_DEFAULT,
         )
     }.orEmpty()
 
@@ -91,7 +91,7 @@ fun Event.toSummaryDisplayModel(
         dateTimeFormatter.formatUTCString(
             utcString = endDate,
             formatPattern = EVENT_DATE_FORMAT,
-            timeZone = TimeZone.currentSystemDefault(),
+            timeZone = TimeZone.SYSTEM_DEFAULT,
         )
     }.orEmpty()
 

--- a/data/event/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/event/OctaneGGEventService.kt
+++ b/data/event/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/event/OctaneGGEventService.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.data.event
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.Team
 import com.adammcneilly.pocketleague.data.octanegg.models.OctaneGGEvent
@@ -8,7 +9,6 @@ import com.adammcneilly.pocketleague.data.octanegg.models.OctaneGGEventParticipa
 import com.adammcneilly.pocketleague.data.octanegg.models.toEvent
 import com.adammcneilly.pocketleague.data.octanegg.models.toTeam
 import com.adammcneilly.pocketleague.data.remote.BaseKTORClient
-import kotlinx.datetime.Clock
 
 /**
  * A concrete implementation of [EventRepository] that requests data
@@ -16,14 +16,14 @@ import kotlinx.datetime.Clock
  */
 class OctaneGGEventService(
     private val apiClient: BaseKTORClient,
-    private val clock: Clock,
+    private val timeProvider: TimeProvider,
 ) : RemoteEventService {
 
     override suspend fun getUpcomingEvents(): Result<List<Event>> {
         return apiClient.getResponse<OctaneGGEventListResponse>(
             endpoint = EVENTS_ENDPOINT,
             params = mapOf(
-                "after" to clock.now().toString(),
+                "after" to timeProvider.now().toString(),
                 "group" to "rlcs",
             ),
         ).map { eventListResponse ->
@@ -57,7 +57,7 @@ class OctaneGGEventService(
         return apiClient.getResponse<OctaneGGEventListResponse>(
             endpoint = EVENTS_ENDPOINT,
             params = mapOf(
-                "date" to clock.now().toString(),
+                "date" to timeProvider.now().toString(),
                 "group" to "rlcs",
             ),
         ).map { eventListResponse ->

--- a/data/event/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/event/SQLDelightEventService.kt
+++ b/data/event/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/event/SQLDelightEventService.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.data.event
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.Team
 import com.adammcneilly.pocketleague.data.local.sqldelight.PocketLeagueDB
@@ -22,7 +23,6 @@ import com.squareup.sqldelight.runtime.coroutines.mapToList
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
-import kotlinx.datetime.Clock
 
 /**
  * An implementation of [EventRepository] that requests all data from
@@ -30,14 +30,14 @@ import kotlinx.datetime.Clock
  */
 class SQLDelightEventService(
     private val database: PocketLeagueDB,
-    private val clock: Clock,
+    private val timeProvider: TimeProvider,
 ) : LocalEventService {
 
     override fun getUpcomingEvents(): Flow<List<Event>> {
         return database
             .localEventQueries
             .selectAfterDate(
-                eventDateUTC = clock.now().toString(),
+                eventDateUTC = timeProvider.now().toString(),
             )
             .asFlow()
             .mapToList()
@@ -74,7 +74,7 @@ class SQLDelightEventService(
         return database
             .localEventQueries
             .selectOnDate(
-                eventDateUTC = clock.now().toString(),
+                eventDateUTC = timeProvider.now().toString(),
             )
             .asFlow()
             .mapToList()

--- a/data/match/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/GetPastWeeksMatchesUseCase.kt
+++ b/data/match/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/GetPastWeeksMatchesUseCase.kt
@@ -1,17 +1,16 @@
 package com.adammcneilly.pocketleague.data.match
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.models.Match
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.datetime.Clock
-import kotlin.time.Duration.Companion.days
 
 /**
  * Return an observable type of matches for the past week.
  */
 class GetPastWeeksMatchesUseCase(
     private val matchRepository: MatchRepository,
-    private val clock: Clock,
+    private val timeProvider: TimeProvider,
 ) {
     /**
      *  @see[GetPastWeeksMatchesUseCase]
@@ -19,8 +18,10 @@ class GetPastWeeksMatchesUseCase(
     fun getPastWeeksMatches(): Flow<List<Match>> {
         return matchRepository
             .getMatchesInDateRange(
-                startDateUTC = clock.now().minus(7.days).toString(),
-                endDateUTC = clock.now().toString(),
+                // TODO: Provide a way to subtract days
+                // startDateUTC = timeProvider.now().minus(7.days).toString(),
+                startDateUTC = timeProvider.now(),
+                endDateUTC = timeProvider.now(),
             )
             .map { matchList ->
                 matchList.sortedByDescending(Match::dateUTC)

--- a/data/match/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/GetPastWeeksMatchesUseCase.kt
+++ b/data/match/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/GetPastWeeksMatchesUseCase.kt
@@ -5,6 +5,8 @@ import com.adammcneilly.pocketleague.core.models.Match
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
+private const val DAYS_PER_WEEK = 7
+
 /**
  * Return an observable type of matches for the past week.
  */
@@ -18,9 +20,7 @@ class GetPastWeeksMatchesUseCase(
     fun getPastWeeksMatches(): Flow<List<Match>> {
         return matchRepository
             .getMatchesInDateRange(
-                // TODO: Provide a way to subtract days
-                // startDateUTC = timeProvider.now().minus(7.days).toString(),
-                startDateUTC = timeProvider.now(),
+                startDateUTC = timeProvider.daysAgo(DAYS_PER_WEEK),
                 endDateUTC = timeProvider.now(),
             )
             .map { matchList ->

--- a/data/match/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/OctaneGGMatchService.kt
+++ b/data/match/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/OctaneGGMatchService.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.data.match
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.EventStage
 import com.adammcneilly.pocketleague.core.models.Match
@@ -7,7 +8,6 @@ import com.adammcneilly.pocketleague.data.octanegg.models.OctaneGGMatch
 import com.adammcneilly.pocketleague.data.octanegg.models.OctaneGGMatchListResponse
 import com.adammcneilly.pocketleague.data.octanegg.models.toMatch
 import com.adammcneilly.pocketleague.data.remote.BaseKTORClient
-import kotlinx.datetime.Clock
 
 /**
  * An implementation of [RemoteMatchService] that requests
@@ -15,7 +15,7 @@ import kotlinx.datetime.Clock
  */
 class OctaneGGMatchService(
     private val apiClient: BaseKTORClient,
-    private val clock: Clock,
+    private val timeProvider: TimeProvider,
 ) : RemoteMatchService {
 
     override suspend fun getMatchDetail(matchId: Match.Id): Result<Match> {
@@ -49,7 +49,7 @@ class OctaneGGMatchService(
         return apiClient.getResponse<OctaneGGMatchListResponse>(
             endpoint = MATCHES_ENDPOINT,
             params = mapOf(
-                "after" to clock.now(),
+                "after" to timeProvider.now(),
                 "group" to "rlcs",
             ),
         ).map { octaneMatchListResponse ->

--- a/data/match/src/commonTest/kotlin/com/adammcneilly/pocketleague/data/match/OctaneGGMatchServiceTest.kt
+++ b/data/match/src/commonTest/kotlin/com/adammcneilly/pocketleague/data/match/OctaneGGMatchServiceTest.kt
@@ -1,6 +1,5 @@
 package com.adammcneilly.pocketleague.data.match
 
-import com.adammcneilly.pocketleague.core.datetime.DebugClock
 import com.adammcneilly.pocketleague.core.models.Match
 import com.adammcneilly.pocketleague.core.test.readTestData
 import com.adammcneilly.pocketleague.data.remote.test.FakeKTORClient
@@ -22,7 +21,7 @@ class OctaneGGMatchServiceTest {
 
         val service = OctaneGGMatchService(
             apiClient = client,
-            clock = DebugClock(),
+            timeProvider = DebugClock(),
         )
 
         val response = service.getMatchDetail(Match.Id("123")).getOrThrow()

--- a/data/match/src/commonTest/kotlin/com/adammcneilly/pocketleague/data/match/OctaneGGMatchServiceTest.kt
+++ b/data/match/src/commonTest/kotlin/com/adammcneilly/pocketleague/data/match/OctaneGGMatchServiceTest.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.data.match
 
+import com.adammcneilly.pocketleague.core.datetime.DebugTimeProvider
 import com.adammcneilly.pocketleague.core.models.Match
 import com.adammcneilly.pocketleague.core.test.readTestData
 import com.adammcneilly.pocketleague.data.remote.test.FakeKTORClient
@@ -21,7 +22,7 @@ class OctaneGGMatchServiceTest {
 
         val service = OctaneGGMatchService(
             apiClient = client,
-            timeProvider = DebugClock(),
+            timeProvider = DebugTimeProvider(),
         )
 
         val response = service.getMatchDetail(Match.Id("123")).getOrThrow()

--- a/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/EventFragmentMapper.kt
+++ b/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/EventFragmentMapper.kt
@@ -1,16 +1,15 @@
 package com.adammcneilly.pocketleague.data.startgg.mappers
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.models.EventStage
 import com.adammcneilly.pocketleague.data.startgg.fragment.EventFragment
 
 /**
  * Convert an [EventFragment] GQL model into an [EventStage] from the pocket league domain.
  */
-fun EventFragment.toEventStage(): EventStage {
+fun EventFragment.toEventStage(timeProvider: TimeProvider): EventStage {
     val startDateUtc = (this.startAt as? Int)?.let { startAt ->
-        // TODO: Move this into a shared file
-        // Instant.fromEpochSeconds(startAt.toLong()).toString()
-        null
+        timeProvider.fromEpochSeconds(startAt.toLong())
     }
 
     return EventStage(

--- a/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/EventFragmentMapper.kt
+++ b/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/EventFragmentMapper.kt
@@ -2,14 +2,15 @@ package com.adammcneilly.pocketleague.data.startgg.mappers
 
 import com.adammcneilly.pocketleague.core.models.EventStage
 import com.adammcneilly.pocketleague.data.startgg.fragment.EventFragment
-import kotlinx.datetime.Instant
 
 /**
  * Convert an [EventFragment] GQL model into an [EventStage] from the pocket league domain.
  */
 fun EventFragment.toEventStage(): EventStage {
     val startDateUtc = (this.startAt as? Int)?.let { startAt ->
-        Instant.fromEpochSeconds(startAt.toLong()).toString()
+        // TODO: Move this into a shared file
+        // Instant.fromEpochSeconds(startAt.toLong()).toString()
+        null
     }
 
     return EventStage(

--- a/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/SetFragmentMapper.kt
+++ b/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/SetFragmentMapper.kt
@@ -6,14 +6,15 @@ import com.adammcneilly.pocketleague.core.models.MatchTeamResult
 import com.adammcneilly.pocketleague.core.models.StageRound
 import com.adammcneilly.pocketleague.core.models.Team
 import com.adammcneilly.pocketleague.data.startgg.fragment.SetFragment
-import kotlinx.datetime.Instant
 
 /**
  * Convert a [SetFragment] GQL model into a [Match] entity from the pocket league domain.
  */
 fun SetFragment.toMatch(): Match {
     val startDateUTC = (this.startAt as? Int)?.let { startAt ->
-        Instant.fromEpochSeconds(startAt.toLong()).toString()
+        // TODO: Move this into a shared file
+        // Instant.fromEpochSeconds(startAt.toLong()).toString()
+        null
     }
 
     val orderedSlots = this.slots?.sortedBy { it?.slotIndex }!!

--- a/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/SetFragmentMapper.kt
+++ b/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/SetFragmentMapper.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.data.startgg.mappers
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.models.Format
 import com.adammcneilly.pocketleague.core.models.Match
 import com.adammcneilly.pocketleague.core.models.MatchTeamResult
@@ -10,11 +11,9 @@ import com.adammcneilly.pocketleague.data.startgg.fragment.SetFragment
 /**
  * Convert a [SetFragment] GQL model into a [Match] entity from the pocket league domain.
  */
-fun SetFragment.toMatch(): Match {
+fun SetFragment.toMatch(timeProvider: TimeProvider): Match {
     val startDateUTC = (this.startAt as? Int)?.let { startAt ->
-        // TODO: Move this into a shared file
-        // Instant.fromEpochSeconds(startAt.toLong()).toString()
-        null
+        timeProvider.fromEpochSeconds(startAt.toLong())
     }
 
     val orderedSlots = this.slots?.sortedBy { it?.slotIndex }!!
@@ -32,7 +31,7 @@ fun SetFragment.toMatch(): Match {
 
     return Match(
         id = Match.Id(this.id.orEmpty()),
-        event = this.event?.tournament?.tournamentFragment?.toEvent()!!,
+        event = this.event?.tournament?.tournamentFragment?.toEvent(timeProvider)!!,
         dateUTC = startDateUTC,
         blueTeam = blueSlot.toMatchTeamResult(
             teamWins = blueTeamWins,
@@ -42,7 +41,7 @@ fun SetFragment.toMatch(): Match {
             teamWins = orangeTeamWins,
             winnerId = this.winnerId,
         ),
-        stage = this.event.eventFragment.toEventStage(),
+        stage = this.event.eventFragment.toEventStage(timeProvider),
         // We should be able to get this information from the API,
         // we just need to add more to this mapping function.
         format = Format(),

--- a/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/TournamentFragmentMapper.kt
+++ b/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/TournamentFragmentMapper.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.data.startgg.mappers
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.EventRegion
 import com.adammcneilly.pocketleague.core.models.EventTier
@@ -8,17 +9,13 @@ import com.adammcneilly.pocketleague.data.startgg.fragment.TournamentFragment
 /**
  * Converts a [TournamentFragment] GQL model into an [Event] within the Pocket League domain.
  */
-fun TournamentFragment.toEvent(): Event {
+fun TournamentFragment.toEvent(timeProvider: TimeProvider): Event {
     val startUtc = (this.startAt as? Int)?.let { startAt ->
-        // TODO: Move this into shared module
-        // Instant.fromEpochSeconds(startAt.toLong()).toString()
-        null
+        timeProvider.fromEpochSeconds(startAt.toLong())
     }
 
     val endUtc = (this.endAt as? Int)?.let { endAt ->
-        // TODO: Move this into a shared module
-        // Instant.fromEpochSeconds(endAt.toLong()).toString()
-        null
+        timeProvider.fromEpochSeconds(endAt.toLong())
     }
 
     return Event(
@@ -28,7 +25,7 @@ fun TournamentFragment.toEvent(): Event {
         endDateUTC = endUtc,
         imageURL = this.images?.firstOrNull()?.url,
         stages = this.events?.mapNotNull {
-            it?.eventFragment?.toEventStage()
+            it?.eventFragment?.toEventStage(timeProvider)
         }.orEmpty(),
         lan = this.hasOfflineEvents == true,
         // Start API doesn't have this information, so can we remove it, or make it null, or something else?

--- a/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/TournamentFragmentMapper.kt
+++ b/data/startgg/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/startgg/mappers/TournamentFragmentMapper.kt
@@ -4,18 +4,21 @@ import com.adammcneilly.pocketleague.core.models.Event
 import com.adammcneilly.pocketleague.core.models.EventRegion
 import com.adammcneilly.pocketleague.core.models.EventTier
 import com.adammcneilly.pocketleague.data.startgg.fragment.TournamentFragment
-import kotlinx.datetime.Instant
 
 /**
  * Converts a [TournamentFragment] GQL model into an [Event] within the Pocket League domain.
  */
 fun TournamentFragment.toEvent(): Event {
     val startUtc = (this.startAt as? Int)?.let { startAt ->
-        Instant.fromEpochSeconds(startAt.toLong()).toString()
+        // TODO: Move this into shared module
+        // Instant.fromEpochSeconds(startAt.toLong()).toString()
+        null
     }
 
     val endUtc = (this.endAt as? Int)?.let { endAt ->
-        Instant.fromEpochSeconds(endAt.toLong()).toString()
+        // TODO: Move this into a shared module
+        // Instant.fromEpochSeconds(endAt.toLong()).toString()
+        null
     }
 
     return Event(

--- a/feature/eventdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/eventdetail/EventDetailPresenter.kt
+++ b/feature/eventdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/eventdetail/EventDetailPresenter.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.displaymodels.EventDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.MatchDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.toDetailDisplayModel
@@ -24,7 +25,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
-import kotlinx.datetime.Clock
 
 private val placeholderMatches = listOf(
     MatchDetailDisplayModel.placeholder,
@@ -40,7 +40,7 @@ class EventDetailPresenter(
     private val eventRepository: EventRepository,
     private val matchRepository: MatchRepository,
     private val onMatchClicked: (Match.Id) -> Unit,
-    private val clock: Clock,
+    private val timeProvider: TimeProvider,
 ) : Presenter<EventDetailScreen.State> {
 
     @Composable
@@ -125,7 +125,7 @@ class EventDetailPresenter(
                     .getMatchesForEventStage(eventId, stageId)
                     .map { matchList ->
                         matchList.map { match ->
-                            match.toDetailDisplayModel(clock)
+                            match.toDetailDisplayModel(timeProvider)
                         }
                     }
                     .onStart {

--- a/feature/eventdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/eventdetail/EventDetailScreen.kt
+++ b/feature/eventdetail/src/commonMain/kotlin/com/adammcneilly/pocketleague/feature/eventdetail/EventDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.feature.eventdetail
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.displaymodels.EventDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.MatchDetailDisplayModel
 import com.adammcneilly.pocketleague.core.feature.CommonParcelize
@@ -14,7 +15,6 @@ import com.slack.circuit.runtime.Screen
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.datetime.Clock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -85,7 +85,7 @@ data class EventDetailScreen(
     ) : Presenter.Factory, KoinComponent {
         private val eventRepository: EventRepository by inject()
         private val matchRepository: MatchRepository by inject()
-        private val clock: Clock by inject()
+        private val timeProvider: TimeProvider by inject()
 
         override fun create(screen: Screen, navigator: Navigator, context: CircuitContext): Presenter<*>? {
             return when (screen) {
@@ -94,7 +94,7 @@ data class EventDetailScreen(
                         eventId = com.adammcneilly.pocketleague.core.models.Event.Id(screen.eventId),
                         eventRepository = eventRepository,
                         matchRepository = matchRepository,
-                        clock = clock,
+                        timeProvider = timeProvider,
                         onMatchClicked = { matchId ->
                             navigateToMatch.invoke(navigator, matchId)
                         },

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/DateTimeModule.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/DateTimeModule.kt
@@ -1,18 +1,18 @@
 package com.adammcneilly.pocketleague.shared.app.di
 
 import com.adammcneilly.pocketleague.core.datetime.DateTimeFormatter
-import com.adammcneilly.pocketleague.core.datetime.DebugClock
+import com.adammcneilly.pocketleague.core.datetime.DebugTimeProvider
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.datetime.dateTimeFormatter
-import kotlinx.datetime.Clock
 import org.koin.dsl.module
 
 /**
  * Defines any dependencies related to date and time management.
  */
 val dateTimeModule = module {
-    single<Clock> {
-//        Clock.System
-        DebugClock()
+    single<TimeProvider> {
+        // SystemTimeProvider
+        DebugTimeProvider()
     }
 
     single<DateTimeFormatter> {

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/LocalModule.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/LocalModule.kt
@@ -24,7 +24,7 @@ val localModule = module {
     single<LocalEventService> {
         SQLDelightEventService(
             database = get(),
-            clock = get(),
+            timeProvider = get(),
         )
     }
 

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/RemoteModule.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/di/RemoteModule.kt
@@ -20,7 +20,7 @@ val remoteModule = module {
     single<RemoteMatchService> {
         OctaneGGMatchService(
             apiClient = get(),
-            clock = get(),
+            timeProvider = get(),
         )
     }
 
@@ -33,7 +33,7 @@ val remoteModule = module {
     single<RemoteEventService> {
         OctaneGGEventService(
             apiClient = get(),
-            clock = get(),
+            timeProvider = get(),
         )
     }
 

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/feed/FeedPresenter.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/feed/FeedPresenter.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.displaymodels.EventGroupDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.MatchDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.toDetailDisplayModel
@@ -20,7 +21,6 @@ import com.slack.circuit.runtime.presenter.Presenter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.datetime.Clock
 
 private const val PLACEHOLDER_LIST_COUNT = 3
 
@@ -30,7 +30,7 @@ private const val PLACEHOLDER_LIST_COUNT = 3
 class FeedPresenter(
     private val getPastWeeksMatchesUseCase: GetPastWeeksMatchesUseCase,
     private val eventRepository: EventRepository,
-    private val clock: Clock,
+    private val timeProvider: TimeProvider,
     private val navigator: Navigator,
 ) : Presenter<FeedScreen.State> {
 
@@ -94,7 +94,7 @@ class FeedPresenter(
         .getPastWeeksMatches()
         .map { matchList ->
             matchList.map { match ->
-                match.toDetailDisplayModel(clock)
+                match.toDetailDisplayModel(timeProvider)
             }
         }
 

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/feed/FeedScreen.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/feed/FeedScreen.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.shared.app.feed
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.displaymodels.EventGroupDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.MatchDetailDisplayModel
 import com.adammcneilly.pocketleague.core.feature.CommonParcelize
@@ -16,7 +17,6 @@ import com.slack.circuit.runtime.Screen
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.datetime.Clock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -91,10 +91,10 @@ object FeedScreen : Screen {
      */
     object PresenterFactory : Presenter.Factory, KoinComponent {
         private val matchRepository: MatchRepository by inject()
-        private val clock: Clock by inject()
+        private val timeProvider: TimeProvider by inject()
         private val getPastWeeksMatchesUseCase = GetPastWeeksMatchesUseCase(
             matchRepository = matchRepository,
-            clock = clock,
+            timeProvider = timeProvider,
         )
         private val eventRepository: EventRepository by inject()
 
@@ -103,7 +103,7 @@ object FeedScreen : Screen {
                 FeedScreen -> FeedPresenter(
                     getPastWeeksMatchesUseCase = getPastWeeksMatchesUseCase,
                     eventRepository = eventRepository,
-                    clock = clock,
+                    timeProvider = timeProvider,
                     navigator = navigator,
                 )
 

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailPresenter.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailPresenter.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.MatchDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.toDetailDisplayModel
@@ -20,7 +21,6 @@ import com.slack.circuit.runtime.presenter.Presenter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.datetime.Clock
 
 /**
  * State management container for the [MatchDetailScreen].
@@ -29,7 +29,7 @@ class MatchDetailPresenter(
     private val matchId: Match.Id,
     private val gameService: GameService,
     private val matchRepository: MatchRepository,
-    private val clock: Clock,
+    private val timeProvider: TimeProvider,
     private val navigator: Navigator,
 ) : Presenter<MatchDetailScreen.State> {
 
@@ -57,7 +57,7 @@ class MatchDetailPresenter(
             matchRepository
                 .getMatchDetail(matchId)
                 .map { match ->
-                    match.toDetailDisplayModel(clock)
+                    match.toDetailDisplayModel(timeProvider)
                 }
                 .onEach { displayModel ->
                     match = displayModel

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailScreen.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.pocketleague.shared.app.match
 
+import com.adammcneilly.pocketleague.core.datetime.TimeProvider
 import com.adammcneilly.pocketleague.core.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pocketleague.core.displaymodels.MatchDetailDisplayModel
 import com.adammcneilly.pocketleague.core.feature.CommonParcelize
@@ -15,7 +16,6 @@ import com.slack.circuit.runtime.Screen
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
 import com.slack.circuit.runtime.ui.ui
-import kotlinx.datetime.Clock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -100,7 +100,7 @@ data class MatchDetailScreen(
     object PresenterFactory : Presenter.Factory, KoinComponent {
         private val gameService: GameService by inject()
         private val matchRepository: MatchRepository by inject()
-        private val clock: Clock by inject()
+        private val timeProvider: TimeProvider by inject()
 
         override fun create(screen: Screen, navigator: Navigator, context: CircuitContext): Presenter<*>? {
             return when (screen) {
@@ -108,7 +108,7 @@ data class MatchDetailScreen(
                     matchId = Match.Id(screen.matchId),
                     gameService = gameService,
                     matchRepository = matchRepository,
-                    clock = clock,
+                    timeProvider = timeProvider,
                     navigator = navigator,
                 )
 


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Removes the transitive dependency to Kotlin datetime. This way we can obscure all the date management to a specific module. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

CI passing is enough, also manually smoke tested. 