### PR TITLE
Fixing match detail crash. 

### DIFF
--- a/data/match/impl/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/impl/StoreMatchRepository.kt
+++ b/data/match/impl/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/impl/StoreMatchRepository.kt
@@ -53,15 +53,25 @@ class StoreMatchRepository(
                         storeResponse.value
                     }
 
+                    is StoreReadResponse.NoNewData -> {
+                        emptyList()
+                    }
+
                     is StoreReadResponse.Error.Exception,
                     is StoreReadResponse.Error.Message,
-                    is StoreReadResponse.NoNewData,
                     -> {
+                        // If an error happens, should we surface that?
+                        // If an error happens syncing remote data
+                        // we could just show an empty match list, BUT we should log something
+                        // (Firebase, Crashlytics, etc) that this error occurred.
                         emptyList()
                     }
 
                     is StoreReadResponse.Loading -> {
                         // Ideally we return some indicator here that loading happened.
+                        // Loading is more interesting, because we can consider what "loading" means.
+                        // First app open -> we are actually loading the data to show you.
+                        // Next app open -> we have data to show you, but we could be refreshing it.
                         emptyList()
                     }
                 }

--- a/data/match/impl/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/impl/StoreMatchRepository.kt
+++ b/data/match/impl/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/impl/StoreMatchRepository.kt
@@ -47,7 +47,8 @@ class StoreMatchRepository(
         ).onEach { response ->
             println("ADAMLOG - Response: $response")
         }.mapNotNull { storeResponse ->
-            // Still need to handle all types?
+            // Still need to handle all storeResponse types
+            // and prefer not to return an empty list unless it's actually empty.
             storeResponse.dataOrNull().orEmpty()
         }
     }

--- a/data/match/impl/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/impl/StoreMatchRepository.kt
+++ b/data/match/impl/src/commonMain/kotlin/com/adammcneilly/pocketleague/data/match/impl/StoreMatchRepository.kt
@@ -7,14 +7,12 @@ import com.adammcneilly.pocketleague.data.match.api.MatchRepository
 import com.adammcneilly.pocketleague.data.match.api.RemoteMatchService
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
 import org.mobilenativefoundation.store.store5.StoreBuilder
 import org.mobilenativefoundation.store.store5.StoreReadRequest
 import org.mobilenativefoundation.store.store5.StoreReadResponse
-import org.mobilenativefoundation.store.store5.StoreReadResponseOrigin
 
 /**
  * A repository class for matches that uses the Store library.
@@ -48,9 +46,6 @@ class StoreMatchRepository(
                 refresh = refreshCache,
             ),
         )
-            .filter { storeResponse ->
-                storeResponse.origin is StoreReadResponseOrigin.SourceOfTruth
-            }
             .distinctUntilChanged()
             .map { storeResponse ->
                 when (storeResponse) {

--- a/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailPresenter.kt
+++ b/shared/app/src/commonMain/kotlin/com/adammcneilly/pocketleague/shared/app/match/MatchDetailPresenter.kt
@@ -21,6 +21,7 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 
 /**
@@ -59,8 +60,11 @@ class MatchDetailPresenter(
 
             matchRepository
                 .stream(request)
-                .map { matchList ->
-                    matchList.first().toDetailDisplayModel(timeProvider)
+                .mapNotNull { matchList ->
+                    matchList.firstOrNull()
+                }
+                .map { match ->
+                    match.toDetailDisplayModel(timeProvider)
                 }
                 .onEach { displayModel ->
                     match = displayModel


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Crash happened by trying to reference the first item in a list that could have been empty, safe guarded via flow filtering. 
